### PR TITLE
Always use absolute path.

### DIFF
--- a/bids2table/_bids2table.py
+++ b/bids2table/_bids2table.py
@@ -53,7 +53,7 @@ def bids2table(
     if not (return_df or persistent):
         raise ValueError("persistent and return_df should not both be False")
 
-    root = Path(root)
+    root = Path(root).expanduser().resolve()
     if not root.is_dir():
         raise FileNotFoundError(f"root directory {root} does not exists")
 
@@ -68,7 +68,7 @@ def bids2table(
     if output is None:
         output = root / "index.b2t"
     else:
-        output = Path(output)
+        output = Path(output).expanduser().resolve()
 
     stale = overwrite or incremental or worker_id is not None
     if output.exists() and not stale:


### PR DESCRIPTION
This PR expands `~` and resolves the `root` and `output` paths. This achieves two things:

- Paths relative to home (e.g. `~/repositories/bids2table/`) are now accepted.
- All relative paths are resolved to absolute paths. This guards against the current directory changing elsewhere in the code.

