### PR TITLE
Simplify logging

### DIFF
--- a/bids2table/__main__.py
+++ b/bids2table/__main__.py
@@ -2,9 +2,8 @@ import argparse
 import sys
 from pathlib import Path
 
-from elbow.utils import setup_logging
-
 from bids2table import bids2table
+from bids2table.logging import setup_logging
 
 
 def main():
@@ -52,7 +51,7 @@ def main():
 
     args = parser.parse_args()
 
-    setup_logging("INFO" if args.verbose else "ERROR")
+    setup_logging(level="INFO" if args.verbose else "WARNING")
 
     bids2table(
         root=args.root,

--- a/bids2table/_b2t.py
+++ b/bids2table/_b2t.py
@@ -5,12 +5,11 @@ from typing import Optional
 from elbow.builders import build_parquet, build_table
 from elbow.sources.filesystem import Crawler
 from elbow.typing import StrOrPath
-from elbow.utils import setup_logging
 
 from bids2table.extractors.bids import extract_bids_subdir
 from bids2table.table import BIDSTable
 
-setup_logging()
+logger = logging.getLogger("bids2table")
 
 
 def bids2table(
@@ -70,15 +69,15 @@ def bids2table(
     stale = overwrite or incremental or worker_id is not None
     if index_path.exists() and not stale:
         if return_table:
-            logging.info("Loading cached index %s", index_path)
+            logger.info("Loading cached index %s", index_path)
             tab = BIDSTable.from_parquet(index_path)
         else:
-            logging.info("Found cached index %s; nothing to do", index_path)
+            logger.info("Found cached index %s; nothing to do", index_path)
             tab = None
         return tab
 
     if not persistent:
-        logging.info("Building index in memory")
+        logger.info("Building index in memory")
         df = build_table(
             source=source,
             extract=extract_bids_subdir,
@@ -88,7 +87,7 @@ def bids2table(
         tab = BIDSTable.from_df(df)
         return tab
 
-    logging.info("Building persistent Parquet index")
+    logger.info("Building persistent Parquet index")
     build_parquet(
         source=source,
         extract=extract_bids_subdir,

--- a/bids2table/extractors/bids.py
+++ b/bids2table/extractors/bids.py
@@ -12,6 +12,8 @@ from bids2table.entities import BIDSEntities
 from .dataset import extract_dataset
 from .metadata import extract_metadata, is_associated_sidecar
 
+logger = logging.getLogger(__name__)
+
 
 def extract_bids_file(path: StrOrPath) -> Optional[Record]:
     """
@@ -23,7 +25,7 @@ def extract_bids_file(path: StrOrPath) -> Optional[Record]:
     try:
         entities = BIDSEntities.from_path(path)
     except (TypeError, ValueError) as exc:
-        logging.warning(
+        logger.warning(
             "Incomplete and/or invalid entities in file %s", path, exc_info=exc
         )
         return None

--- a/bids2table/extractors/dataset.py
+++ b/bids2table/extractors/dataset.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from elbow.record import Record
 from elbow.typing import StrOrPath
 
+logger = logging.getLogger(__name__)
+
 
 def extract_dataset(path: StrOrPath) -> Record:
     """
@@ -55,7 +57,7 @@ def identify_bids_dataset(path: StrOrPath) -> Tuple[Optional[str], Optional[Path
         parent = parent.parent
 
     if len(parts) == 0:
-        logging.warning("File %s is not part of any valid BIDS dataset.", path)
+        logger.warning("File %s is not part of any valid BIDS dataset.", path)
         return None, None
 
     parts = parts[: top_idx + 1]

--- a/bids2table/extractors/image.py
+++ b/bids2table/extractors/image.py
@@ -16,6 +16,8 @@ try:
 except ModuleNotFoundError:
     has_nifti = False
 
+logger = logging.getLogger(__name__)
+
 # TODO: add more
 IMAGE_EXTENSIONS = {".nii", ".nii.gz"}
 
@@ -29,7 +31,7 @@ def extract_image_meta(path: StrOrPath, *, backend: str = "nibabel") -> Record:
         try:
             header, affine = _read_image_meta(str(path), backend=backend)
         except (ImageFileError, SystemError) as exc:
-            logging.warning("Failed to load image %s", path, exc_info=exc)
+            logger.warning("Failed to load image %s", path, exc_info=exc)
 
     rec = Record(
         {"image_header": header, "image_affine": affine},

--- a/bids2table/extractors/metadata.py
+++ b/bids2table/extractors/metadata.py
@@ -10,6 +10,8 @@ from bids2table.entities import parse_bids_entities
 
 from .inheritance import _glob, find_bids_parents
 
+logger = logging.getLogger(__name__)
+
 
 def extract_metadata(path: StrOrPath) -> Record:
     """
@@ -26,7 +28,7 @@ def extract_metadata(path: StrOrPath) -> Record:
             try:
                 metadata.update(json.load(f))
             except (json.JSONDecodeError, TypeError):
-                logging.warning(
+                logger.warning(
                     f"Bad JSON sidecar data {path}\n\n" + traceback.format_exc()
                 )
 

--- a/bids2table/logging.py
+++ b/bids2table/logging.py
@@ -1,0 +1,70 @@
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, Optional, Tuple, Union
+
+
+class RepetitiveFilter(logging.Filter):
+    """
+    Suppress similar log messages after a number of repeats.
+    """
+
+    def __init__(self, max_repeats: int = 5):
+        self.max_repeats = max_repeats
+
+        self._counts: Dict[Tuple[str, int], int] = {}
+
+    def filter(self, record: logging.LogRecord):
+        key = record.pathname, record.lineno
+        count = self._counts.get(key, 0)
+        if count == self.max_repeats:
+            record.msg += " [future messages suppressed]"
+        self._counts[key] = count + 1
+        return count <= self.max_repeats
+
+
+def setup_logging(
+    name: Optional[str] = None,
+    level: Optional[Union[int, str]] = None,
+    log_path: Optional[Union[str, Path]] = None,
+    max_repeats: Optional[int] = 5,
+    overwrite: bool = False,
+    propagate: bool = False,
+) -> logging.Logger:
+    """
+    Setup a logger in a particular way.
+    """
+    logger = logging.getLogger(name=name)
+    if len(logger.handlers) > 0 and not overwrite:
+        return logger
+
+    if level is not None:
+        logger.setLevel(level)
+
+    # clean up any pre-existing filters and handlers
+    for f in logger.filters:
+        logger.removeFilter(f)
+    for h in logger.handlers:
+        logger.removeHandler(h)
+        h.close()
+
+    if max_repeats:
+        logger.addFilter(RepetitiveFilter(max_repeats=max_repeats))
+
+    fmt = "[%(levelname)s %(name)s %(asctime)s]: %(message)s"
+    formatter = logging.Formatter(fmt, datefmt="%y-%m-%d %H:%M:%S")
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+    stream_handler.setLevel(logger.level)
+    logger.addHandler(stream_handler)
+
+    if log_path is not None:
+        file_handler = logging.FileHandler(log_path, mode="a")
+        file_handler.setFormatter(formatter)
+        file_handler.setLevel(logger.level)
+        logger.addHandler(file_handler)
+
+    if not propagate:
+        logger.propagate = False
+    return logger


### PR DESCRIPTION
Fixes issues related to overwriting root logger. Simplifies logging approach following best practice (custom logger in each module with inherited settings). Adds a `setup_logging()` function for setting up loggers in my preferred way. However by default this is only called in the CLI.