### PR TITLE
Fix non-deterministic BIDS table file order in `test_table`

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,20 @@
+import logging
+from pathlib import Path
+
+from bids2table.logging import setup_logging
+
+
+def test_setup_logging(tmp_path: Path):
+    log_path = tmp_path / "log.txt"
+    logger = setup_logging(
+        level=logging.INFO,
+        log_path=tmp_path / "log.txt",
+        max_repeats=5,
+        overwrite=True,
+    )
+
+    for ii in range(0, 10):
+        logger.info(f"log msg {ii}")
+
+    log = log_path.read_text().strip().split("\n")
+    assert len(log) == 6


### PR DESCRIPTION
Fix non-deterministic BIDS table file order in `test_table` and add more asserts to check the expected fields. Fixes #26.