### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,11 @@ repos:
     rev: v1.2.0
     hooks:
     - id: mypy
+
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in pyproject.toml
+  rev: v2.2.6
+  hooks:
+  - id: codespell
+    additional_dependencies:
+    - tomli

--- a/.pylintrc
+++ b/.pylintrc
@@ -45,7 +45,7 @@ confidence=
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once).You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes

--- a/bids2table/entities.py
+++ b/bids2table/entities.py
@@ -209,9 +209,7 @@ class _BIDSEntitiesBase:
             path = prefix / path
         return path
 
-    def with_update(
-        self, entities: Optional[Dict[str, Any]] = None, **kwargs
-    ) -> Self:
+    def with_update(self, entities: Optional[Dict[str, Any]] = None, **kwargs) -> Self:
         """
         Create a new instance with updated entities.
         """

--- a/bids2table/entities.py
+++ b/bids2table/entities.py
@@ -184,7 +184,7 @@ class _BIDSEntitiesBase:
         int_format: str = "%d",
     ) -> Path:
         """
-        Generate a filepath based on the entitities.
+        Generate a filepath based on the entities.
         """
         special = {"datatype", "suffix", "ext"}
         data = self.to_dict(valid_only=valid_only)
@@ -210,14 +210,14 @@ class _BIDSEntitiesBase:
         return path
 
     def with_update(
-        self, entitities: Optional[Dict[str, Any]] = None, **kwargs
+        self, entities: Optional[Dict[str, Any]] = None, **kwargs
     ) -> Self:
         """
         Create a new instance with updated entities.
         """
         data = self.to_dict(valid_only=False)
-        if entitities:
-            data.update(entitities)
+        if entities:
+            data.update(entities)
         if kwargs:
             data.update(kwargs)
         return self.__class__.from_dict(data)

--- a/example/example.ipynb
+++ b/example/example.ipynb
@@ -3629,7 +3629,7 @@
    "source": [
     "## Using the command-line interface\n",
     "\n",
-    "bids2table comes with a command-line iterface `bids2table` (alias `b2t`). Check out the help message."
+    "bids2table comes with a command-line interface `bids2table` (alias `b2t`). Check out the help message."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ ignore_missing_imports = true
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*'
+skip = '.git*,venv*'
 check-hidden = true
-ignore-regex = '(^\s*"image/\S+": ".*|ND)'
+ignore-regex = '(^\s*"image/\S+": ".*|\bND\b)'
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,5 +80,5 @@ ignore_missing_imports = true
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git*'
 check-hidden = true
-ignore-regex = '^\s*"image/\S+": ".*'
+ignore-regex = '(^\s*"image/\S+": ".*|ND)'
 # ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,10 @@ log_cli_level = "DEBUG"
 [tool.mypy]
 no_strict_optional = true
 ignore_missing_imports = true
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+ignore-regex = '^\s*"image/\S+": ".*'
+# ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.