### PR TITLE
Overload `bids2table` signature for specific return types

### DIFF
--- a/bids2table/_b2t.py
+++ b/bids2table/_b2t.py
@@ -1,7 +1,7 @@
 import logging
 from functools import partial
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Literal, Optional, overload
 
 from elbow.builders import build_parquet, build_table
 from elbow.sources.filesystem import Crawler
@@ -13,6 +13,34 @@ from bids2table.table import BIDSTable
 logger = logging.getLogger("bids2table")
 
 
+@overload
+def bids2table(
+    root: StrOrPath,
+    *,
+    with_meta: bool = True,
+    persistent: bool = False,
+    index_path: Optional[StrOrPath] = None,
+    exclude: Optional[List[str]] = None,
+    incremental: bool = False,
+    overwrite: bool = False,
+    workers: Optional[int] = None,
+    worker_id: Optional[int] = None,
+    return_table: Literal[True] = True,
+) -> BIDSTable: ...
+@overload
+def bids2table(
+    root: StrOrPath,
+    *,
+    with_meta: bool = True,
+    persistent: bool = False,
+    index_path: Optional[StrOrPath] = None,
+    exclude: Optional[List[str]] = None,
+    incremental: bool = False,
+    overwrite: bool = False,
+    workers: Optional[int] = None,
+    worker_id: Optional[int] = None,
+    return_table: Literal[False],
+) -> None: ...
 def bids2table(
     root: StrOrPath,
     *,

--- a/bids2table/_b2t.py
+++ b/bids2table/_b2t.py
@@ -1,7 +1,7 @@
 import logging
 from functools import partial
 from pathlib import Path
-from typing import List, Literal, Optional, overload
+from typing import List, Optional
 
 from elbow.builders import build_parquet, build_table
 from elbow.sources.filesystem import Crawler
@@ -13,34 +13,6 @@ from bids2table.table import BIDSTable
 logger = logging.getLogger("bids2table")
 
 
-@overload
-def bids2table(
-    root: StrOrPath,
-    *,
-    with_meta: bool = True,
-    persistent: bool = False,
-    index_path: Optional[StrOrPath] = None,
-    exclude: Optional[List[str]] = None,
-    incremental: bool = False,
-    overwrite: bool = False,
-    workers: Optional[int] = None,
-    worker_id: Optional[int] = None,
-    return_table: Literal[True] = True,
-) -> BIDSTable: ...
-@overload
-def bids2table(
-    root: StrOrPath,
-    *,
-    with_meta: bool = True,
-    persistent: bool = False,
-    index_path: Optional[StrOrPath] = None,
-    exclude: Optional[List[str]] = None,
-    incremental: bool = False,
-    overwrite: bool = False,
-    workers: Optional[int] = None,
-    worker_id: Optional[int] = None,
-    return_table: Literal[False],
-) -> None: ...
 def bids2table(
     root: StrOrPath,
     *,

--- a/bids2table/_b2t.pyi
+++ b/bids2table/_b2t.pyi
@@ -1,0 +1,34 @@
+from typing import List, Literal, Optional, overload
+
+from elbow.typing import StrOrPath
+
+from bids2table.table import BIDSTable
+
+@overload
+def bids2table(
+    root: StrOrPath,
+    *,
+    with_meta: bool = True,
+    persistent: bool = False,
+    index_path: Optional[StrOrPath] = None,
+    exclude: Optional[List[str]] = None,
+    incremental: bool = False,
+    overwrite: bool = False,
+    workers: Optional[int] = None,
+    worker_id: Optional[int] = None,
+    return_table: Literal[True] = True,
+) -> BIDSTable: ...
+@overload
+def bids2table(
+    root: StrOrPath,
+    *,
+    with_meta: bool = True,
+    persistent: bool = False,
+    index_path: Optional[StrOrPath] = None,
+    exclude: Optional[List[str]] = None,
+    incremental: bool = False,
+    overwrite: bool = False,
+    workers: Optional[int] = None,
+    worker_id: Optional[int] = None,
+    return_table: Literal[False],
+) -> None: ...


### PR DESCRIPTION
Instead of typehinting `BIDSTable | None` for the return type of `bids2table`, this PR updates the typehinting to dynamically be `BIDSTable` for `bids2table(return_table=True)` (or unspecified, which with `return_table=True` by default) or `None` for `bids2table(return_table=False)`.

[dynamic return type screen grab](https://github.com/user-attachments/assets/853796ee-8f8f-4754-9fe4-62698fe0311f)

The functionality is the same between just a4bcf5eadea3ee83a253f73c4736b4c1a7686cd6 or both commits here. The difference is the first commit does the overload in the main file https://github.com/childmindresearch/bids2table/blob/a4bcf5eadea3ee83a253f73c4736b4c1a7686cd6/bids2table/_b2t.py#L16-L56 while the second commit moves the overload to a [stub file](https://typing.readthedocs.io/en/latest/reference/stubs.html) for the sake of abstraction / less scrolling in the main file.

No hard feelings if you don't want this specific typehinting.