### PR TITLE
Fix: modality refers to modality suffixes

### DIFF
--- a/bids2table/table.py
+++ b/bids2table/table.py
@@ -74,10 +74,19 @@ class BIDSTable(pd.DataFrame):
     @cached_property
     def modalities(self) -> List[str]:
         """
-        Get all modalities present in the table.
+        Get data modalities present in the table.
+
+        Currently includes: https://github.com/bids-standard/bids-specification/blob/master/src/schema/objects/suffixes.yaml
+        which can include events, etc.
         """
-        # TODO: Is this the right way to get the modality
-        return self.ent["mod"].unique().tolist()
+        return self.suffixes
+
+    @cached_property
+    def suffixes(self) -> List[str]:
+        """
+        Get all suffixes present in the table.
+        """
+        return self.ent["suffix"].unique().tolist()
 
     @cached_property
     def subjects(self) -> List[str]:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -48,7 +48,13 @@ def test_table(tab: BIDSTable):
     assert subtab.ds.shape == (10, 4)
 
     assert len(tab.datatypes) == 2
-    assert len(tab.modalities) == 1
+    assert set(tab.modalities).issuperset(
+        {
+            "T1w",
+            "inplaneT2",
+            "bold",
+        }
+    )
     assert len(tab.subjects) == 16
     assert len(tab.entities) == 3
 


### PR DESCRIPTION
Thanks for this helpful library!

Looking at :
https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#mod

it looks like `mod-<label>` is only used for defacing masks, which might not be of interest to many. `bids-examples` only has 1 dataset that uses it.

BIDS seems to use modality to mostly refer to datatypes (already included in this API) or [modality suffixes](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html)