### PR TITLE
Fix cloudpathlib error when package not available

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,11 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Run tests
+
+      - name: Run tests without cloudpathlib
+        run: |
+          uv run pytest tests
+      - name: Run tests with cloudpathlib
         run: |
           uv run --all-extras pytest \
             --junitxml=pytest.xml \

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -15,7 +15,6 @@ from glob import glob
 from typing import Any, Callable, Generator, Iterable, Sequence
 
 import pyarrow as pa
-from cloudpathlib import CloudPath
 from tqdm import tqdm
 
 from ._entities import (
@@ -24,7 +23,7 @@ from ._entities import (
     validate_bids_entities,
 )
 from ._logging import setup_logger
-from ._pathlib import PathT, as_path
+from ._pathlib import CloudPath, PathT, as_path, cloudpathlib_is_available
 
 _BIDS_SUBJECT_DIR_PATTERN = re.compile(r"sub-[a-zA-Z0-9]+")
 
@@ -404,7 +403,7 @@ def _index_bids_subject_dir(
 
     records = []
     # Use built-in rglob methods for CloudPath and py3.13+
-    if isinstance(path, CloudPath):
+    if cloudpathlib_is_available() and isinstance(path, CloudPath):
         paths = map(as_path, path.rglob("sub-*"))
     elif sys.version_info >= (3, 13):
         paths = map(as_path, path.rglob("sub-*", recurse_symlinks=True))

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -52,6 +52,9 @@ def test_find_bids_datasets():
     assert datasets_no_derivatives == expected_datasets_no_derivatives
 
 
+@pytest.mark.skipif(
+    not cloudpathlib_is_available(), reason="cloudpathlib not installed"
+)
 def test_find_bids_datasets_s3():
     root = "s3://openneuro.org"
     datasets = list(islice(indexing.find_bids_datasets(root, maxdepth=2), 10))


### PR DESCRIPTION
Resolves #61.

Uses `CloudPath` as defined in `_pathlib.py`. Also checks for `cloudpathlib` availability in first condition (potential definition of `CloudPath` if library isn't defined). 

Additionally adds a test run to the CI without `cloudpathlib` installed. Note, only the run with `cloudpathlib` installed generates a coverage report (there is overlap here anyways, aside from the 2 additional tests for cloud datasets). The additional test is more to catch any issues that may crop up without the additional package.