### PR TITLE
Adds pybids compatability layer to bids2table

### DIFF
--- a/bids2table/pybids/__init__.py
+++ b/bids2table/pybids/__init__.py
@@ -1,0 +1,14 @@
+__all__ = [
+    "BIDSLayout",
+    "BIDSFile",
+    "Query",
+    "listify"
+]
+
+from ._layout import BIDSLayout
+from ._bidsfile import BIDSFile
+from ._utils import (
+    Query,
+    listify,
+)
+

--- a/bids2table/pybids/__init__.py
+++ b/bids2table/pybids/__init__.py
@@ -1,14 +1,8 @@
-__all__ = [
-    "BIDSLayout",
-    "BIDSFile",
-    "Query",
-    "listify"
-]
+__all__ = ["BIDSLayout", "BIDSFile", "Query", "listify"]
 
-from ._layout import BIDSLayout
 from ._bidsfile import BIDSFile
+from ._layout import BIDSLayout
 from ._utils import (
     Query,
     listify,
 )
-

--- a/bids2table/pybids/_bidsfile.py
+++ b/bids2table/pybids/_bidsfile.py
@@ -5,7 +5,7 @@ Provides a PyBIDS-compatible file object that can parse and cache
 BIDS entities from file paths.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .._entities import parse_bids_entities
 
@@ -33,9 +33,9 @@ class BIDSFile:
             path: Path to BIDS file (absolute or relative)
         """
         self.path = str(path)
-        self._entities: Optional[Dict[str, Any]] = None
+        self._entities: dict[str, Any] | None = None
 
-    def get_entities(self) -> Dict[str, Any]:
+    def get_entities(self) -> dict[str, Any]:
         """
         Parse and return BIDS entities from filename.
 

--- a/bids2table/pybids/_bidsfile.py
+++ b/bids2table/pybids/_bidsfile.py
@@ -5,8 +5,7 @@ Provides a PyBIDS-compatible file object that can parse and cache
 BIDS entities from file paths.
 """
 
-from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
 
 from .._entities import parse_bids_entities
 

--- a/bids2table/pybids/_bidsfile.py
+++ b/bids2table/pybids/_bidsfile.py
@@ -1,0 +1,96 @@
+"""
+BIDSFile wrapper for file paths with entity access.
+
+Provides a PyBIDS-compatible file object that can parse and cache
+BIDS entities from file paths.
+"""
+
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+from .._entities import parse_bids_entities
+
+
+class BIDSFile:
+    """
+    Wrapper around a BIDS file path with entity parsing.
+
+    Provides PyBIDS-compatible interface for accessing file entities.
+    Entities are lazily parsed and cached on first access.
+
+    Example:
+        >>> from bids2table_compat import BIDSFile
+        >>> f = BIDSFile('sub-01/func/sub-01_task-rest_bold.nii.gz')
+        >>> entities = f.get_entities()
+        >>> print(entities)
+        {'sub': '01', 'task': 'rest', 'suffix': 'bold', 'ext': '.nii.gz'}
+    """
+
+    def __init__(self, path: str):
+        """
+        Initialize BIDSFile.
+
+        Args:
+            path: Path to BIDS file (absolute or relative)
+        """
+        self.path = str(path)
+        self._entities: Optional[Dict[str, Any]] = None
+
+    def get_entities(self) -> Dict[str, Any]:
+        """
+        Parse and return BIDS entities from filename.
+
+        Entities are cached after first parse for performance.
+
+        Returns:
+            Dictionary of BIDS entities (e.g., {'sub': '01', 'task': 'rest'})
+        """
+        if self._entities is None:
+            self._entities = parse_bids_entities(self.path)
+        return self._entities
+
+    def __str__(self) -> str:
+        """String representation showing file path."""
+        return self.path
+
+    def __repr__(self) -> str:
+        """Developer-friendly representation."""
+        return f"BIDSFile('{self.path}')"
+
+    def __eq__(self, other) -> bool:
+        """Equality based on path."""
+        if isinstance(other, BIDSFile):
+            return self.path == other.path
+        return False
+
+    def __hash__(self) -> int:
+        """Allow use in sets/dicts."""
+        return hash(self.path)
+
+    def __lt__(self, other) -> bool:
+        """Less-than comparison based on path (for sorting)."""
+        if isinstance(other, BIDSFile):
+            return self.path < other.path
+        return NotImplemented
+
+    def __le__(self, other) -> bool:
+        """Less-than-or-equal comparison based on path."""
+        if isinstance(other, BIDSFile):
+            return self.path <= other.path
+        return NotImplemented
+
+    def __gt__(self, other) -> bool:
+        """Greater-than comparison based on path."""
+        if isinstance(other, BIDSFile):
+            return self.path > other.path
+        return NotImplemented
+
+    def __ge__(self, other) -> bool:
+        """Greater-than-or-equal comparison based on path."""
+        if isinstance(other, BIDSFile):
+            return self.path >= other.path
+        return NotImplemented
+
+    def __contains__(self, item) -> bool:
+        """Check if substring is in the file path (for 'in' operator)."""
+        return item in self.path

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -5,9 +5,9 @@ Provides a PyBIDS-compatible interface for querying BIDS datasets
 while leveraging bids2table's superior performance.
 """
 
-from pathlib import Path
-from typing import Union, Optional, List, Dict, Any
 import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 import pyarrow as pa
@@ -54,7 +54,7 @@ class BIDSLayout:
         cache_path: Optional[Path] = None,
         database_path: Optional[Path] = None,
         reset_database: bool = False,
-        **kwargs
+        **kwargs,
     ):
         # Initialize BIDSLayout with dataset indexing.
         self.root = Path(root).absolute()
@@ -66,12 +66,12 @@ class BIDSLayout:
                 "database_path is deprecated, use cache_path instead. "
                 "Note: cache uses parquet format, not SQLite.",
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
 
         # Set cache path
         if cache_path is None:
-            self.cache_path = self.root / '.bids2table_cache.parquet'
+            self.cache_path = self.root / ".bids2table_cache.parquet"
         else:
             self.cache_path = Path(cache_path)
 
@@ -106,7 +106,7 @@ class BIDSLayout:
                     f"Failed to load cache from {self.cache_path}: {e}. "
                     "Re-indexing dataset.",
                     UserWarning,
-                    stacklevel=3
+                    stacklevel=3,
                 )
 
         # Create new index
@@ -121,7 +121,7 @@ class BIDSLayout:
                 warnings.warn(
                     f"Failed to save cache to {self.cache_path}: {e}",
                     UserWarning,
-                    stacklevel=3
+                    stacklevel=3,
                 )
 
         return tab
@@ -145,7 +145,7 @@ class BIDSLayout:
                 warnings.warn(
                     f"Derivative path does not exist: {deriv_path}",
                     UserWarning,
-                    stacklevel=3
+                    stacklevel=3,
                 )
                 continue
 
@@ -156,11 +156,7 @@ class BIDSLayout:
         if deriv_tabs:
             self._tab = pa.concat_tables([self._tab] + deriv_tabs)
 
-    def get(
-        self,
-        return_type: str = 'file',
-        **entities
-    ) -> List[Union[str, BIDSFile]]:
+    def get(self, return_type: str = "file", **entities) -> List[Union[str, BIDSFile]]:
         """
         Query files by BIDS entities.
 
@@ -195,7 +191,7 @@ class BIDSLayout:
                 warnings.warn(
                     f"Unknown entity '{key}' (not in dataset columns)",
                     UserWarning,
-                    stacklevel=2
+                    stacklevel=2,
                 )
                 continue
 
@@ -217,14 +213,14 @@ class BIDSLayout:
                 result_df = result_df[result_df[key] == value]
 
         # Return based on return_type
-        if return_type == 'filename':
-            return result_df['path'].tolist()
-        elif return_type == 'file':
-            return [BIDSFile(p) for p in result_df['path'].tolist()]
-        elif return_type == 'id':
+        if return_type == "filename":
+            return result_df["path"].tolist()
+        elif return_type == "file":
+            return [BIDSFile(p) for p in result_df["path"].tolist()]
+        elif return_type == "id":
             return result_df.index.tolist()
-        elif return_type == 'dir':
-            dirs = result_df['path'].apply(lambda p: str(Path(p).parent))
+        elif return_type == "dir":
+            dirs = result_df["path"].apply(lambda p: str(Path(p).parent))
             return sorted(dirs.unique().tolist())
         else:
             raise ValueError(
@@ -244,11 +240,11 @@ class BIDSLayout:
         """
         # Common mappings
         mapping = {
-            'subject': 'sub',
-            'session': 'ses',
-            'extension': 'ext',
-            'datatype': 'datatype',
-            'suffix': 'suffix',
+            "subject": "sub",
+            "session": "ses",
+            "extension": "ext",
+            "datatype": "datatype",
+            "suffix": "suffix",
         }
         return mapping.get(key, key)
 
@@ -275,9 +271,9 @@ class BIDSLayout:
                 key = self._map_entity_key(key)
                 if key in filtered_df.columns:
                     filtered_df = filtered_df[filtered_df[key] == value]
-            subjects = filtered_df['sub'].dropna().unique()
+            subjects = filtered_df["sub"].dropna().unique()
         else:
-            subjects = self.df['sub'].dropna().unique()
+            subjects = self.df["sub"].dropna().unique()
 
         return sorted(subjects.tolist())
 
@@ -302,7 +298,7 @@ class BIDSLayout:
 
         # Filter by subject if provided
         if subject is not None:
-            result_df = result_df[result_df['sub'] == subject]
+            result_df = result_df[result_df["sub"] == subject]
 
         # Apply additional filters
         for key, value in filters.items():
@@ -310,7 +306,7 @@ class BIDSLayout:
             if key in result_df.columns:
                 result_df = result_df[result_df[key] == value]
 
-        sessions = result_df['ses'].dropna().unique()
+        sessions = result_df["ses"].dropna().unique()
         return sorted(sessions.tolist())
 
     def get_metadata(self, path: str) -> Dict[str, Any]:
@@ -384,9 +380,30 @@ class BIDSLayout:
 
         # Extract unique values for each entity column
         # Standard BIDS entities that might be present
-        entity_cols = ['sub', 'ses', 'task', 'acq', 'ce', 'rec', 'dir', 'run',
-                       'mod', 'echo', 'flip', 'inv', 'mt', 'part', 'recording',
-                       'suffix', 'space', 'res', 'den', 'label', 'desc', 'datatype']
+        entity_cols = [
+            "sub",
+            "ses",
+            "task",
+            "acq",
+            "ce",
+            "rec",
+            "dir",
+            "run",
+            "mod",
+            "echo",
+            "flip",
+            "inv",
+            "mt",
+            "part",
+            "recording",
+            "suffix",
+            "space",
+            "res",
+            "den",
+            "label",
+            "desc",
+            "datatype",
+        ]
 
         entities = {}
         for col in entity_cols:
@@ -398,10 +415,7 @@ class BIDSLayout:
         return entities
 
     def add_custom_entity(
-        self,
-        name: str,
-        values: Union[List, Dict, Any],
-        overwrite: bool = False
+        self, name: str, values: Union[List, Dict, Any], overwrite: bool = False
     ):
         """
         Add a custom entity column to the layout.
@@ -446,20 +460,20 @@ class BIDSLayout:
         elif isinstance(values, dict):
             # Dict: map from key (assume subject or file path)
             # Try to detect if keys are subjects or paths
-            if values and list(values.keys())[0] in self.df['sub'].values:
+            if values and list(values.keys())[0] in self.df["sub"].values:
                 # Keys are subjects
-                self.df[name] = self.df['sub'].map(values)
+                self.df[name] = self.df["sub"].map(values)
             else:
                 # Keys are file paths or other
-                self.df[name] = self.df['path'].map(values)
+                self.df[name] = self.df["path"].map(values)
         else:
             # Scalar or array-like: assign directly
             self.df[name] = values
 
     def __repr__(self) -> str:
         """String representation of layout."""
-        n_subjects = self.df['sub'].nunique()
-        n_sessions = self.df['ses'].nunique()
+        n_subjects = self.df["sub"].nunique()
+        n_sessions = self.df["ses"].nunique()
         n_files = len(self.df)
 
         return (

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -34,7 +34,6 @@ class BIDSLayout:
 
     Args:
         root: Path to BIDS dataset root
-        validate: Whether to validate BIDS compliance (currently ignored)
         derivatives: Path(s) to derivative datasets to include
         cache_path: Path to parquet cache file (default: {root}/.bids2table_cache.parquet)
         database_path: Legacy parameter (ignored, use cache_path instead)
@@ -49,7 +48,6 @@ class BIDSLayout:
     def __init__(
         self,
         root: Union[str, Path],
-        validate: bool = True,
         derivatives: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
         cache_path: Optional[Path] = None,
         database_path: Optional[Path] = None,
@@ -75,8 +73,6 @@ class BIDSLayout:
         else:
             self.cache_path = Path(cache_path)
 
-        # b2t always validates, so we can contiue
-
         # Load or create index
         self._tab = self._load_or_create_index().flatten()
 
@@ -88,7 +84,7 @@ class BIDSLayout:
         entity_schema = self._tab.schema
         self._entity_map = {}
         for entity in entity_schema:
-            # Pull the name (uesd by B2T) and entity (used by pyBIDS) labels
+            # Pull the name (used by B2T) and entity (used by pyBIDS) labels
             name = entity.metadata[b"name"]
             dname = entity.metadata.get(b"entity", name)
             # Decode them from bytestrings into real strings, and store

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -78,7 +78,7 @@ class BIDSLayout:
         # b2t always validates, so we can contiue
 
         # Load or create index
-        self._tab = self._load_or_create_index()
+        self._tab = self._load_or_create_index().flatten()
 
         # Handle derivatives
         if derivatives is not None:

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -74,7 +74,7 @@ class BIDSLayout:
             self.cache_path = Path(cache_path)
 
         # Load or create index
-        self._tab = self._load_or_create_index().flatten()
+        self._tab = self._load_or_create_index()
 
         # Handle derivatives
         if derivatives is not None:
@@ -92,8 +92,36 @@ class BIDSLayout:
             self._entity_map[dname.decode("utf-8")] = name.decode("utf-8")
             self._entity_map[name.decode("utf-8")] = name.decode("utf-8")
 
+        # Flatten extra entities after
+        self._flatten_extra_entities()
+
         # Convert to pandas DataFrame for querying
         self.df = self._tab.to_pandas(types_mapper=pd.ArrowDtype)
+
+    def _flatten_extra_entities(self) -> None:
+        """Flatten extra entities in the table."""
+        if "extra_entities" not in self._tab.column_names:
+            return
+
+        idx = self._tab.schema.get_field_index("extra_entities")
+        dicts = [
+            dict(r) if r else {} for r in self._tab.column("extra_entities").to_pylist()
+        ]
+        all_keys = set().union(*dicts)
+
+        self._tab = self._tab.remove_column(idx)
+        if all_keys:
+            for k in all_keys:
+                self._tab = self._tab.append_column(
+                    pa.field(k, pa.string()), pa.array([d.get(k) for d in dicts])
+                )
+                self._entity_map[k] = k
+
+        cols = [c for c in self._tab.column_names if c not in ("root", "path")] + [
+            "root",
+            "path",
+        ]
+        self._tab = self._tab.select(cols)
 
     def _load_or_create_index(self) -> pa.Table:
         """
@@ -370,10 +398,6 @@ class BIDSLayout:
         # Extract unique values for each entity column
         entities = {}
         for ekey, evalue in self._entity_map.items():
-            # TODO: think about if we want to handle extra entities here?
-            # Disabled for now since unique and lists don't play nice
-            if evalue == "extra_entities":
-                continue
             if evalue in filtered_df.columns:
                 unique_vals = filtered_df[evalue].dropna().unique().tolist()
                 if unique_vals:  # Only include if not empty

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -1,0 +1,468 @@
+"""
+BIDSLayout compatibility wrapper around bids2table.
+
+Provides a PyBIDS-compatible interface for querying BIDS datasets
+while leveraging bids2table's superior performance.
+"""
+
+from pathlib import Path
+from typing import Union, Optional, List, Dict, Any
+import warnings
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .._indexing import index_dataset
+from .._metadata import load_bids_metadata
+from ._bidsfile import BIDSFile
+from ._utils import Query
+
+
+class BIDSLayout:
+    """
+    PyBIDS-compatible wrapper around bids2table.
+
+    Provides a familiar BIDSLayout interface while using bids2table's
+    fast indexing and efficient querying under the hood.
+
+    Example:
+        >>> from bids2table_compat import BIDSLayout
+        >>> layout = BIDSLayout('/path/to/dataset', validate=False)
+        >>> subjects = layout.get_subjects()
+        >>> files = layout.get(subject='01', suffix='T1w')
+
+    Args:
+        root: Path to BIDS dataset root
+        validate: Whether to validate BIDS compliance (currently ignored)
+        derivatives: Path(s) to derivative datasets to include
+        cache_path: Path to parquet cache file (default: {root}/.bids2table_cache.parquet)
+        database_path: Legacy parameter (ignored, use cache_path instead)
+        reset_database: If True, ignore cache and force re-indexing (useful for benchmarking)
+        **kwargs: Additional arguments (currently ignored)
+
+    Attributes:
+        root: Dataset root path
+        df: Pandas DataFrame with indexed BIDS files
+    """
+
+    def __init__(
+        self,
+        root: Union[str, Path],
+        validate: bool = True,
+        derivatives: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
+        cache_path: Optional[Path] = None,
+        database_path: Optional[Path] = None,
+        reset_database: bool = False,
+        **kwargs
+    ):
+        # Initialize BIDSLayout with dataset indexing.
+        self.root = Path(root).absolute()
+        self.reset_database = reset_database
+
+        # Handle legacy database_path parameter
+        if database_path is not None and cache_path is None:
+            warnings.warn(
+                "database_path is deprecated, use cache_path instead. "
+                "Note: cache uses parquet format, not SQLite.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+
+        # Set cache path
+        if cache_path is None:
+            self.cache_path = self.root / '.bids2table_cache.parquet'
+        else:
+            self.cache_path = Path(cache_path)
+
+        # b2t always validates, so we can contiue
+
+        # Load or create index
+        self._tab = self._load_or_create_index()
+
+        # Handle derivatives
+        if derivatives is not None:
+            self._add_derivatives(derivatives)
+
+        # Convert to pandas DataFrame for querying
+        self.df = self._tab.to_pandas(types_mapper=pd.ArrowDtype)
+
+    def _load_or_create_index(self) -> pa.Table:
+        """
+        Load cached index or create new one.
+
+        Returns:
+            PyArrow table with indexed BIDS files
+        """
+
+        # If reset_database is True, skip cache and force re-index
+        if not self.reset_database and self.cache_path.exists():
+            # Check if cache is stale (optional - could be expensive)
+            # For now, trust the cache exists means it's valid
+            try:
+                return pq.read_table(self.cache_path)
+            except Exception as e:
+                warnings.warn(
+                    f"Failed to load cache from {self.cache_path}: {e}. "
+                    "Re-indexing dataset.",
+                    UserWarning,
+                    stacklevel=3
+                )
+
+        # Create new index
+        tab = index_dataset(str(self.root))
+
+        # Save cache (unless reset_database is True, which implies benchmarking)
+        if not self.reset_database:
+            try:
+                self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+                pq.write_table(tab, self.cache_path)
+            except Exception as e:
+                warnings.warn(
+                    f"Failed to save cache to {self.cache_path}: {e}",
+                    UserWarning,
+                    stacklevel=3
+                )
+
+        return tab
+
+    def _add_derivatives(self, derivatives: Union[str, Path, List[Union[str, Path]]]):
+        """
+        Add derivative datasets to the index.
+
+        Args:
+            derivatives: Path or list of paths to derivative datasets
+        """
+        # Normalize to list
+        if not isinstance(derivatives, list):
+            derivatives = [derivatives]
+
+        # Index each derivative dataset
+        deriv_tabs = []
+        for deriv_path in derivatives:
+            deriv_path = Path(deriv_path)
+            if not deriv_path.exists():
+                warnings.warn(
+                    f"Derivative path does not exist: {deriv_path}",
+                    UserWarning,
+                    stacklevel=3
+                )
+                continue
+
+            deriv_tab = index_dataset(str(deriv_path))
+            deriv_tabs.append(deriv_tab)
+
+        # Concatenate with main table
+        if deriv_tabs:
+            self._tab = pa.concat_tables([self._tab] + deriv_tabs)
+
+    def get(
+        self,
+        return_type: str = 'file',
+        **entities
+    ) -> List[Union[str, BIDSFile]]:
+        """
+        Query files by BIDS entities.
+
+        Args:
+            return_type: Type of return value:
+                - 'file': List of BIDSFile objects
+                - 'filename': List of path strings
+                - 'id': List of row indices
+                - 'dir': List of unique directories
+            **entities: BIDS entity filters (e.g., subject='01', suffix='T1w')
+
+        Returns:
+            List of files matching query (type depends on return_type)
+
+        Example:
+            >>> files = layout.get(subject='01', suffix='T1w', return_type='filename')
+            >>> ['sub-01/anat/sub-01_T1w.nii.gz']
+        """
+        # Start with full dataframe
+        result_df = self.df.copy()
+
+        # Apply filters
+        for key, value in entities.items():
+            # Map common PyBIDS names to b2t column names
+            # PyBIDS uses 'subject', 'session', 'extension'
+            # b2t uses 'sub', 'ses', 'ext'
+            key = self._map_entity_key(key)
+
+            # Check if column exists
+            if key not in result_df.columns:
+                # Unknown entity - could warn or ignore
+                warnings.warn(
+                    f"Unknown entity '{key}' (not in dataset columns)",
+                    UserWarning,
+                    stacklevel=2
+                )
+                continue
+
+            # Handle special Query values
+            if value is Query.OPTIONAL:
+                # Allow any value (including missing) - no filtering
+                continue
+            elif value is Query.NONE:
+                # Match explicit nulls
+                result_df = result_df[result_df[key].isna()]
+            elif value is Query.ANY:
+                # Match any value - don't filter
+                continue
+            elif isinstance(value, list):
+                # List of values - use isin()
+                result_df = result_df[result_df[key].isin(value)]
+            else:
+                # Single value - exact match
+                result_df = result_df[result_df[key] == value]
+
+        # Return based on return_type
+        if return_type == 'filename':
+            return result_df['path'].tolist()
+        elif return_type == 'file':
+            return [BIDSFile(p) for p in result_df['path'].tolist()]
+        elif return_type == 'id':
+            return result_df.index.tolist()
+        elif return_type == 'dir':
+            dirs = result_df['path'].apply(lambda p: str(Path(p).parent))
+            return sorted(dirs.unique().tolist())
+        else:
+            raise ValueError(
+                f"Unknown return_type: {return_type}. "
+                "Valid options: 'file', 'filename', 'id', 'dir'"
+            )
+
+    def _map_entity_key(self, key: str) -> str:
+        """
+        Map PyBIDS entity names to b2t column names.
+
+        Args:
+            key: PyBIDS entity name
+
+        Returns:
+            b2t column name
+        """
+        # Common mappings
+        mapping = {
+            'subject': 'sub',
+            'session': 'ses',
+            'extension': 'ext',
+            'datatype': 'datatype',
+            'suffix': 'suffix',
+        }
+        return mapping.get(key, key)
+
+    def get_subjects(self, **filters) -> List[str]:
+        """
+        Get list of unique subject IDs.
+
+        Args:
+            **filters: Optional entity filters to apply before extracting subjects
+
+        Returns:
+            Sorted list of subject IDs (without 'sub-' prefix)
+
+        Example:
+            >>> layout.get_subjects()
+            ['01', '02', '03']
+            >>> layout.get_subjects(suffix='bold')
+            ['01', '02']  # Only subjects with BOLD data
+        """
+        if filters:
+            # Apply filters first
+            filtered_df = self.df.copy()
+            for key, value in filters.items():
+                key = self._map_entity_key(key)
+                if key in filtered_df.columns:
+                    filtered_df = filtered_df[filtered_df[key] == value]
+            subjects = filtered_df['sub'].dropna().unique()
+        else:
+            subjects = self.df['sub'].dropna().unique()
+
+        return sorted(subjects.tolist())
+
+    def get_sessions(self, subject: Optional[str] = None, **filters) -> List[str]:
+        """
+        Get list of unique session IDs.
+
+        Args:
+            subject: Optional subject ID to filter by
+            **filters: Optional entity filters
+
+        Returns:
+            Sorted list of session IDs (without 'ses-' prefix)
+
+        Example:
+            >>> layout.get_sessions()
+            ['01', '02']
+            >>> layout.get_sessions(subject='01')
+            ['01', '02']
+        """
+        result_df = self.df.copy()
+
+        # Filter by subject if provided
+        if subject is not None:
+            result_df = result_df[result_df['sub'] == subject]
+
+        # Apply additional filters
+        for key, value in filters.items():
+            key = self._map_entity_key(key)
+            if key in result_df.columns:
+                result_df = result_df[result_df[key] == value]
+
+        sessions = result_df['ses'].dropna().unique()
+        return sorted(sessions.tolist())
+
+    def get_metadata(self, path: str) -> Dict[str, Any]:
+        """
+        Load metadata from JSON sidecar(s) for a given file.
+
+        Uses BIDS inheritance principle to merge metadata from
+        dataset, subject, and session levels.
+
+        Args:
+            path: Path to BIDS file (absolute or relative to dataset root)
+
+        Returns:
+            Dictionary of metadata fields
+
+        Example:
+            >>> metadata = layout.get_metadata('sub-01/func/sub-01_task-rest_bold.nii.gz')
+            >>> metadata['RepetitionTime']
+            2.0
+        """
+        # Convert to absolute path if relative
+        if not Path(path).is_absolute():
+            path = str(self.root / path)
+
+        return load_bids_metadata(path, str(self.root))
+
+    def get_file(self, path: str) -> BIDSFile:
+        """
+        Get BIDSFile object for a given path.
+
+        Args:
+            path: Path to file
+
+        Returns:
+            BIDSFile object wrapping the path
+
+        Example:
+            >>> bids_file = layout.get_file('sub-01/anat/sub-01_T1w.nii.gz')
+            >>> entities = bids_file.get_entities()
+        """
+        return BIDSFile(path)
+
+    def get_entities(self, **filters) -> Dict[str, List[str]]:
+        """
+        Get dictionary of all entities and their unique values.
+
+        Args:
+            **filters: Optional entity filters to apply before extracting entities
+
+        Returns:
+            Dictionary where keys are entity names and values are lists of unique values
+
+        Example:
+            >>> entities = layout.get_entities()
+            >>> entities['task']
+            ['rest', 'nback', 'faces']
+            >>> # With filters
+            >>> entities = layout.get_entities(suffix='bold')
+            >>> entities['sub']
+            ['01', '02']  # Only subjects with BOLD data
+        """
+        # Apply filters if provided
+        if filters:
+            filtered_df = self.df.copy()
+            for key, value in filters.items():
+                key = self._map_entity_key(key)
+                if key in filtered_df.columns:
+                    filtered_df = filtered_df[filtered_df[key] == value]
+        else:
+            filtered_df = self.df
+
+        # Extract unique values for each entity column
+        # Standard BIDS entities that might be present
+        entity_cols = ['sub', 'ses', 'task', 'acq', 'ce', 'rec', 'dir', 'run',
+                       'mod', 'echo', 'flip', 'inv', 'mt', 'part', 'recording',
+                       'suffix', 'space', 'res', 'den', 'label', 'desc', 'datatype']
+
+        entities = {}
+        for col in entity_cols:
+            if col in filtered_df.columns:
+                unique_vals = filtered_df[col].dropna().unique().tolist()
+                if unique_vals:  # Only include if not empty
+                    entities[col] = sorted(unique_vals)
+
+        return entities
+
+    def add_custom_entity(
+        self,
+        name: str,
+        values: Union[List, Dict, Any],
+        overwrite: bool = False
+    ):
+        """
+        Add a custom entity column to the layout.
+
+        This is a convenience method for adding custom metadata that can be
+        queried like standard BIDS entities.
+
+        Args:
+            name: Name of the custom entity (will become a column)
+            values: Values to assign. Can be:
+                - Single value: Applied to all rows
+                - List/array: Must match length of df
+                - Dict: Maps from subject/file to value
+                - Function: Applied to each row via df.apply()
+            overwrite: If True, overwrite existing column (default: False)
+
+        Raises:
+            ValueError: If column exists and overwrite=False
+
+        Example:
+            >>> layout = BIDSLayout('/data')
+            >>> # Add constant
+            >>> layout.add_custom_entity('processing_status', 'pending')
+            >>> # Add from dict
+            >>> qc = {'01': 'pass', '02': 'fail'}
+            >>> layout.add_custom_entity('qc_grade', qc)
+            >>> # Add from function
+            >>> layout.add_custom_entity('modality', lambda row:
+            ...     'anat' if row['datatype'] == 'anat' else 'func')
+            >>> # Query it
+            >>> passed = layout.get(qc_grade='pass')
+        """
+        if name in self.df.columns and not overwrite:
+            raise ValueError(
+                f"Entity '{name}' already exists. Use overwrite=True to replace."
+            )
+
+        # Handle different value types
+        if callable(values):
+            # Function: apply to each row
+            self.df[name] = self.df.apply(values, axis=1)
+        elif isinstance(values, dict):
+            # Dict: map from key (assume subject or file path)
+            # Try to detect if keys are subjects or paths
+            if values and list(values.keys())[0] in self.df['sub'].values:
+                # Keys are subjects
+                self.df[name] = self.df['sub'].map(values)
+            else:
+                # Keys are file paths or other
+                self.df[name] = self.df['path'].map(values)
+        else:
+            # Scalar or array-like: assign directly
+            self.df[name] = values
+
+    def __repr__(self) -> str:
+        """String representation of layout."""
+        n_subjects = self.df['sub'].nunique()
+        n_sessions = self.df['ses'].nunique()
+        n_files = len(self.df)
+
+        return (
+            f"BIDSLayout(root='{self.root}', "
+            f"subjects={n_subjects}, sessions={n_sessions}, files={n_files})"
+        )

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -449,3 +449,7 @@ class BIDSLayout:
             f"BIDSLayout(root='{self.root}', "
             f"subjects={n_subjects}, sessions={n_sessions}, files={n_files})"
         )
+
+    def to_df(self) -> pd.DataFrame:
+        """Explicit method to return converted dataframe, mirroring pybids."""
+        return self.df

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -14,6 +14,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from .._indexing import index_dataset
+from .._entities import get_bids_entity_arrow_schema
 from .._metadata import load_bids_metadata
 from ._bidsfile import BIDSFile
 from ._utils import Query
@@ -83,6 +84,18 @@ class BIDSLayout:
         # Handle derivatives
         if derivatives is not None:
             self._add_derivatives(derivatives)
+
+        # Load the entity schema and create a LUT
+        entity_schema = self._tab.schema
+        self._entity_map = {}
+        for entity in entity_schema:
+            # Pull the name (uesd by B2T) and entity (used by pyBIDS) labels
+            name = entity.metadata[b'name']
+            dname = entity.metadata.get(b'entity', name)
+            # Decode them from bytestrings into real strings, and store
+            # so that either the entity or shortname will return appropriately
+            self._entity_map[dname.decode('utf-8')] = name.decode('utf-8')
+            self._entity_map[name.decode('utf-8')] = name.decode('utf-8')
 
         # Convert to pandas DataFrame for querying
         self.df = self._tab.to_pandas(types_mapper=pd.ArrowDtype)
@@ -183,7 +196,8 @@ class BIDSLayout:
             # Map common PyBIDS names to b2t column names
             # PyBIDS uses 'subject', 'session', 'extension'
             # b2t uses 'sub', 'ses', 'ext'
-            key = self._map_entity_key(key)
+            # Fallback to the current key if it's not in the dict
+            key = self._entity_map.get(key, key)
 
             # Check if column exists
             if key not in result_df.columns:
@@ -228,26 +242,6 @@ class BIDSLayout:
                 "Valid options: 'file', 'filename', 'id', 'dir'"
             )
 
-    def _map_entity_key(self, key: str) -> str:
-        """
-        Map PyBIDS entity names to b2t column names.
-
-        Args:
-            key: PyBIDS entity name
-
-        Returns:
-            b2t column name
-        """
-        # Common mappings
-        mapping = {
-            "subject": "sub",
-            "session": "ses",
-            "extension": "ext",
-            "datatype": "datatype",
-            "suffix": "suffix",
-        }
-        return mapping.get(key, key)
-
     def get_subjects(self, **filters) -> List[str]:
         """
         Get list of unique subject IDs.
@@ -268,7 +262,7 @@ class BIDSLayout:
             # Apply filters first
             filtered_df = self.df.copy()
             for key, value in filters.items():
-                key = self._map_entity_key(key)
+                key = self._entity_map.get(key, key)
                 if key in filtered_df.columns:
                     filtered_df = filtered_df[filtered_df[key] == value]
             subjects = filtered_df["sub"].dropna().unique()
@@ -380,33 +374,10 @@ class BIDSLayout:
 
         # Extract unique values for each entity column
         # Standard BIDS entities that might be present
-        entity_cols = [
-            "sub",
-            "ses",
-            "task",
-            "acq",
-            "ce",
-            "rec",
-            "dir",
-            "run",
-            "mod",
-            "echo",
-            "flip",
-            "inv",
-            "mt",
-            "part",
-            "recording",
-            "suffix",
-            "space",
-            "res",
-            "den",
-            "label",
-            "desc",
-            "datatype",
-        ]
+        entity_schema = get_bids_entity_arrow_schema()
 
         entities = {}
-        for col in entity_cols:
+        for entity, cfg in entity_schema.items():
             if col in filtered_df.columns:
                 unique_vals = filtered_df[col].dropna().unique().tolist()
                 if unique_vals:  # Only include if not empty
@@ -469,6 +440,8 @@ class BIDSLayout:
         else:
             # Scalar or array-like: assign directly
             self.df[name] = values
+
+        self._entity_map[name] = name
 
     def __repr__(self) -> str:
         """String representation of layout."""

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -7,7 +7,7 @@ while leveraging bids2table's superior performance.
 
 import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import pandas as pd
 import pyarrow as pa
@@ -47,10 +47,10 @@ class BIDSLayout:
 
     def __init__(
         self,
-        root: Union[str, Path],
-        derivatives: Optional[Union[str, Path, List[Union[str, Path]]]] = None,
-        cache_path: Optional[Path] = None,
-        database_path: Optional[Path] = None,
+        root: str | Path,
+        derivatives: str | Path | list[str | Path] | None = None,
+        cache_path: Path | None = None,
+        database_path: Path | None = None,
         reset_database: bool = False,
         **kwargs,
     ):
@@ -162,7 +162,7 @@ class BIDSLayout:
 
         return tab
 
-    def _add_derivatives(self, derivatives: Union[str, Path, List[Union[str, Path]]]):
+    def _add_derivatives(self, derivatives: str | Path | list[str | Path]):
         """
         Add derivative datasets to the index.
 
@@ -192,7 +192,7 @@ class BIDSLayout:
         if deriv_tabs:
             self._tab = pa.concat_tables([self._tab] + deriv_tabs)
 
-    def get(self, return_type: str = "file", **entities) -> List[Union[str, BIDSFile]]:
+    def get(self, return_type: str = "file", **entities) -> list[str | BIDSFile]:
         """
         Query files by BIDS entities.
 
@@ -265,7 +265,7 @@ class BIDSLayout:
                 "Valid options: 'file', 'filename', 'id', 'dir'"
             )
 
-    def get_subjects(self, **filters) -> List[str]:
+    def get_subjects(self, **filters) -> list[str]:
         """
         Get list of unique subject IDs.
 
@@ -294,7 +294,7 @@ class BIDSLayout:
 
         return sorted(subjects.tolist())
 
-    def get_sessions(self, subject: Optional[str] = None, **filters) -> List[str]:
+    def get_sessions(self, subject: str | None = None, **filters) -> list[str]:
         """
         Get list of unique session IDs.
 
@@ -326,7 +326,7 @@ class BIDSLayout:
         sessions = result_df["ses"].dropna().unique()
         return sorted(sessions.tolist())
 
-    def get_metadata(self, path: str) -> Dict[str, Any]:
+    def get_metadata(self, path: str) -> dict[str, Any]:
         """
         Load metadata from JSON sidecar(s) for a given file.
 
@@ -366,7 +366,7 @@ class BIDSLayout:
         """
         return BIDSFile(path)
 
-    def get_entities(self, **filters) -> Dict[str, List[str]]:
+    def get_entities(self, **filters) -> dict[str, list[str]]:
         """
         Get dictionary of all entities and their unique values.
 
@@ -406,7 +406,10 @@ class BIDSLayout:
         return entities
 
     def add_custom_entity(
-        self, name: str, values: Union[List, Dict, Any], overwrite: bool = False
+        self,
+        name: str,
+        values: list[Any] | dict[str, Any] | Any,
+        overwrite: bool = False,
     ):
         """
         Add a custom entity column to the layout.

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -14,7 +14,6 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from .._indexing import index_dataset
-from .._entities import get_bids_entity_arrow_schema
 from .._metadata import load_bids_metadata
 from ._bidsfile import BIDSFile
 from ._utils import Query
@@ -90,12 +89,12 @@ class BIDSLayout:
         self._entity_map = {}
         for entity in entity_schema:
             # Pull the name (uesd by B2T) and entity (used by pyBIDS) labels
-            name = entity.metadata[b'name']
-            dname = entity.metadata.get(b'entity', name)
+            name = entity.metadata[b"name"]
+            dname = entity.metadata.get(b"entity", name)
             # Decode them from bytestrings into real strings, and store
             # so that either the entity or shortname will return appropriately
-            self._entity_map[dname.decode('utf-8')] = name.decode('utf-8')
-            self._entity_map[name.decode('utf-8')] = name.decode('utf-8')
+            self._entity_map[dname.decode("utf-8")] = name.decode("utf-8")
+            self._entity_map[name.decode("utf-8")] = name.decode("utf-8")
 
         # Convert to pandas DataFrame for querying
         self.df = self._tab.to_pandas(types_mapper=pd.ArrowDtype)
@@ -373,15 +372,16 @@ class BIDSLayout:
             filtered_df = self.df
 
         # Extract unique values for each entity column
-        # Standard BIDS entities that might be present
-        entity_schema = get_bids_entity_arrow_schema()
-
         entities = {}
-        for entity, cfg in entity_schema.items():
-            if col in filtered_df.columns:
-                unique_vals = filtered_df[col].dropna().unique().tolist()
+        for ekey, evalue in self._entity_map.items():
+            # TODO: think about if we want to handle extra entities here?
+            # Disabled for now since unique and lists don't play nice
+            if evalue == "extra_entities":
+                continue
+            if evalue in filtered_df.columns:
+                unique_vals = filtered_df[evalue].dropna().unique().tolist()
                 if unique_vals:  # Only include if not empty
-                    entities[col] = sorted(unique_vals)
+                    entities[evalue] = sorted(unique_vals)
 
         return entities
 

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -348,7 +348,7 @@ class BIDSLayout:
         if not Path(path).is_absolute():
             path = str(self.root / path)
 
-        return load_bids_metadata(path, str(self.root))
+        return load_bids_metadata(path)
 
     def get_file(self, path: str) -> BIDSFile:
         """

--- a/bids2table/pybids/_utils.py
+++ b/bids2table/pybids/_utils.py
@@ -1,0 +1,52 @@
+"""Utility functions for PyBIDS compatibility."""
+
+from typing import Any
+
+
+class Query:
+    """Special query values for entity filtering."""
+
+    # Sentinel objects for special filtering behavior
+    OPTIONAL = object()  # Allow missing or any value
+    NONE = object()      # Match explicit null/missing
+    ANY = object()       # Match any value (don't filter)
+
+    def __repr__(self):
+        return "Query"
+
+
+def listify(obj: Any) -> list:
+    """
+    Convert an object to a list if it isn't already one.
+
+    This is a PyBIDS utility function that niworkflows and other packages use.
+
+    Parameters
+    ----------
+    obj : Any
+        Object to convert to list
+
+    Returns
+    -------
+    list
+        If obj is None, returns empty list
+        If obj is already a list/tuple, returns as list
+        Otherwise returns [obj]
+
+    Examples
+    --------
+    >>> listify(None)
+    []
+    >>> listify("test")
+    ['test']
+    >>> listify(["a", "b"])
+    ['a', 'b']
+    >>> listify(("a", "b"))
+    ['a', 'b']
+    """
+    if obj is None:
+        return []
+    elif isinstance(obj, (list, tuple)):
+        return list(obj)
+    else:
+        return [obj]

--- a/bids2table/pybids/_utils.py
+++ b/bids2table/pybids/_utils.py
@@ -8,8 +8,8 @@ class Query:
 
     # Sentinel objects for special filtering behavior
     OPTIONAL = object()  # Allow missing or any value
-    NONE = object()      # Match explicit null/missing
-    ANY = object()       # Match any value (don't filter)
+    NONE = object()  # Match explicit null/missing
+    ANY = object()  # Match any value (don't filter)
 
     def __repr__(self):
         return "Query"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ cloud = ["cloudpathlib[s3,gs]>=0.21.0"]
 s3 = [
     "cloudpathlib[s3]>=0.21.0",
 ] # Include s3 to not break backwards compatibility
+pybids = ["pandas>=2.0.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/pybids/test_bidsfile.py
+++ b/tests/pybids/test_bidsfile.py
@@ -1,0 +1,74 @@
+"""Tests for BIDSFile class."""
+
+import pytest
+from bids2table.pybids import BIDSFile
+
+
+def test_bidsfile_init():
+    """Test BIDSFile initialization."""
+    f = BIDSFile('sub-01/anat/sub-01_T1w.nii.gz')
+    assert f.path == 'sub-01/anat/sub-01_T1w.nii.gz'
+    assert f._entities is None  # Not yet parsed
+
+
+def test_bidsfile_get_entities():
+    """Test entity parsing from filename."""
+    f = BIDSFile('sub-01_ses-02_task-rest_bold.nii.gz')
+    entities = f.get_entities()
+
+    assert isinstance(entities, dict)
+    assert entities.get('sub') == '01'
+    assert entities.get('ses') == '02'
+    assert entities.get('task') == 'rest'
+    assert entities.get('suffix') == 'bold'
+
+
+def test_bidsfile_entities_cached():
+    """Test that entities are cached after first parse."""
+    f = BIDSFile('sub-01_T1w.nii.gz')
+
+    # First call
+    entities1 = f.get_entities()
+    assert f._entities is not None
+
+    # Second call should return cached version
+    entities2 = f.get_entities()
+    assert entities1 is entities2  # Same object
+
+
+def test_bidsfile_str():
+    """Test string representation."""
+    f = BIDSFile('sub-01/anat/sub-01_T1w.nii.gz')
+    assert str(f) == 'sub-01/anat/sub-01_T1w.nii.gz'
+
+
+def test_bidsfile_repr():
+    """Test developer representation."""
+    f = BIDSFile('sub-01/anat/sub-01_T1w.nii.gz')
+    assert repr(f) == "BIDSFile('sub-01/anat/sub-01_T1w.nii.gz')"
+
+
+def test_bidsfile_equality():
+    """Test equality comparison."""
+    f1 = BIDSFile('sub-01_T1w.nii.gz')
+    f2 = BIDSFile('sub-01_T1w.nii.gz')
+    f3 = BIDSFile('sub-02_T1w.nii.gz')
+
+    assert f1 == f2
+    assert f1 != f3
+    assert f1 != 'sub-01_T1w.nii.gz'  # Not equal to string
+
+
+def test_bidsfile_hashable():
+    """Test that BIDSFile can be used in sets/dicts."""
+    f1 = BIDSFile('sub-01_T1w.nii.gz')
+    f2 = BIDSFile('sub-01_T1w.nii.gz')
+    f3 = BIDSFile('sub-02_T1w.nii.gz')
+
+    # Can create set
+    file_set = {f1, f2, f3}
+    assert len(file_set) == 2  # f1 and f2 are equal
+
+    # Can use as dict key
+    file_dict = {f1: 'first', f3: 'third'}
+    assert file_dict[f2] == 'first'  # f2 equals f1

--- a/tests/pybids/test_bidsfile.py
+++ b/tests/pybids/test_bidsfile.py
@@ -1,31 +1,30 @@
 """Tests for BIDSFile class."""
 
-import pytest
 from bids2table.pybids import BIDSFile
 
 
 def test_bidsfile_init():
     """Test BIDSFile initialization."""
-    f = BIDSFile('sub-01/anat/sub-01_T1w.nii.gz')
-    assert f.path == 'sub-01/anat/sub-01_T1w.nii.gz'
+    f = BIDSFile("sub-01/anat/sub-01_T1w.nii.gz")
+    assert f.path == "sub-01/anat/sub-01_T1w.nii.gz"
     assert f._entities is None  # Not yet parsed
 
 
 def test_bidsfile_get_entities():
     """Test entity parsing from filename."""
-    f = BIDSFile('sub-01_ses-02_task-rest_bold.nii.gz')
+    f = BIDSFile("sub-01_ses-02_task-rest_bold.nii.gz")
     entities = f.get_entities()
 
     assert isinstance(entities, dict)
-    assert entities.get('sub') == '01'
-    assert entities.get('ses') == '02'
-    assert entities.get('task') == 'rest'
-    assert entities.get('suffix') == 'bold'
+    assert entities.get("sub") == "01"
+    assert entities.get("ses") == "02"
+    assert entities.get("task") == "rest"
+    assert entities.get("suffix") == "bold"
 
 
 def test_bidsfile_entities_cached():
     """Test that entities are cached after first parse."""
-    f = BIDSFile('sub-01_T1w.nii.gz')
+    f = BIDSFile("sub-01_T1w.nii.gz")
 
     # First call
     entities1 = f.get_entities()
@@ -38,37 +37,37 @@ def test_bidsfile_entities_cached():
 
 def test_bidsfile_str():
     """Test string representation."""
-    f = BIDSFile('sub-01/anat/sub-01_T1w.nii.gz')
-    assert str(f) == 'sub-01/anat/sub-01_T1w.nii.gz'
+    f = BIDSFile("sub-01/anat/sub-01_T1w.nii.gz")
+    assert str(f) == "sub-01/anat/sub-01_T1w.nii.gz"
 
 
 def test_bidsfile_repr():
     """Test developer representation."""
-    f = BIDSFile('sub-01/anat/sub-01_T1w.nii.gz')
+    f = BIDSFile("sub-01/anat/sub-01_T1w.nii.gz")
     assert repr(f) == "BIDSFile('sub-01/anat/sub-01_T1w.nii.gz')"
 
 
 def test_bidsfile_equality():
     """Test equality comparison."""
-    f1 = BIDSFile('sub-01_T1w.nii.gz')
-    f2 = BIDSFile('sub-01_T1w.nii.gz')
-    f3 = BIDSFile('sub-02_T1w.nii.gz')
+    f1 = BIDSFile("sub-01_T1w.nii.gz")
+    f2 = BIDSFile("sub-01_T1w.nii.gz")
+    f3 = BIDSFile("sub-02_T1w.nii.gz")
 
     assert f1 == f2
     assert f1 != f3
-    assert f1 != 'sub-01_T1w.nii.gz'  # Not equal to string
+    assert f1 != "sub-01_T1w.nii.gz"  # Not equal to string
 
 
 def test_bidsfile_hashable():
     """Test that BIDSFile can be used in sets/dicts."""
-    f1 = BIDSFile('sub-01_T1w.nii.gz')
-    f2 = BIDSFile('sub-01_T1w.nii.gz')
-    f3 = BIDSFile('sub-02_T1w.nii.gz')
+    f1 = BIDSFile("sub-01_T1w.nii.gz")
+    f2 = BIDSFile("sub-01_T1w.nii.gz")
+    f3 = BIDSFile("sub-02_T1w.nii.gz")
 
     # Can create set
     file_set = {f1, f2, f3}
     assert len(file_set) == 2  # f1 and f2 are equal
 
     # Can use as dict key
-    file_dict = {f1: 'first', f3: 'third'}
-    assert file_dict[f2] == 'first'  # f2 equals f1
+    file_dict = {f1: "first", f3: "third"}
+    assert file_dict[f2] == "first"  # f2 equals f1

--- a/tests/pybids/test_custom_entities.py
+++ b/tests/pybids/test_custom_entities.py
@@ -1,8 +1,9 @@
 """Tests for custom entity functionality."""
 
-import pytest
-from pathlib import Path
 import tempfile
+from pathlib import Path
+
+import pytest
 
 from bids2table.pybids import BIDSLayout
 
@@ -10,7 +11,7 @@ from bids2table.pybids import BIDSLayout
 @pytest.fixture
 def test_dataset():
     """Return path to a test BIDS dataset."""
-    dataset_path = Path(__file__).parents[2] / 'bids-examples' / 'ds001'
+    dataset_path = Path(__file__).parents[2] / "bids-examples" / "ds001"
     if not dataset_path.exists():
         pytest.skip(f"Test dataset not found: {dataset_path}")
     return dataset_path
@@ -20,7 +21,7 @@ def test_dataset():
 def layout(test_dataset):
     """Create a BIDSLayout for testing."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        cache_path = Path(tmpdir) / 'test_cache.parquet'
+        cache_path = Path(tmpdir) / "test_cache.parquet"
         yield BIDSLayout(test_dataset, validate=False, cache_path=cache_path)
 
 
@@ -29,13 +30,13 @@ class TestCustomEntities:
 
     def test_add_constant_value(self, layout):
         """Test adding a constant value to all rows."""
-        layout.add_custom_entity('status', 'pending')
+        layout.add_custom_entity("status", "pending")
 
-        assert 'status' in layout.df.columns
-        assert (layout.df['status'] == 'pending').all()
+        assert "status" in layout.df.columns
+        assert (layout.df["status"] == "pending").all()
 
         # Query with custom entity
-        files = layout.get(status='pending', return_type='filename')
+        files = layout.get(status="pending", return_type="filename")
         assert len(files) == len(layout.df)
 
     def test_add_from_dict_subjects(self, layout):
@@ -45,39 +46,40 @@ class TestCustomEntities:
             pytest.skip("No subjects in dataset")
 
         # Create mapping for first few subjects
-        qc_mapping = {subjects[0]: 'pass', subjects[1]: 'fail'}
-        layout.add_custom_entity('qc_grade', qc_mapping)
+        qc_mapping = {subjects[0]: "pass", subjects[1]: "fail"}
+        layout.add_custom_entity("qc_grade", qc_mapping)
 
-        assert 'qc_grade' in layout.df.columns
+        assert "qc_grade" in layout.df.columns
 
         # Check values
-        sub01_rows = layout.df[layout.df['sub'] == subjects[0]]
-        assert (sub01_rows['qc_grade'] == 'pass').all()
+        sub01_rows = layout.df[layout.df["sub"] == subjects[0]]
+        assert (sub01_rows["qc_grade"] == "pass").all()
 
         # Query with custom entity
-        passed = layout.get(qc_grade='pass', return_type='filename')
-        failed = layout.get(qc_grade='fail', return_type='filename')
+        passed = layout.get(qc_grade="pass", return_type="filename")
+        failed = layout.get(qc_grade="fail", return_type="filename")
 
         assert len(passed) > 0
         assert len(failed) > 0
 
     def test_add_from_function(self, layout):
         """Test adding entity computed from function."""
+
         def categorize(row):
-            if row['suffix'] in ['T1w', 'T2w', 'inplaneT2']:
-                return 'anatomical'
-            elif row['suffix'] == 'bold':
-                return 'functional'
+            if row["suffix"] in ["T1w", "T2w", "inplaneT2"]:
+                return "anatomical"
+            elif row["suffix"] == "bold":
+                return "functional"
             else:
-                return 'other'
+                return "other"
 
-        layout.add_custom_entity('modality_category', categorize)
+        layout.add_custom_entity("modality_category", categorize)
 
-        assert 'modality_category' in layout.df.columns
+        assert "modality_category" in layout.df.columns
 
         # Query with custom entity
-        anat = layout.get(modality_category='anatomical', return_type='filename')
-        func = layout.get(modality_category='functional', return_type='filename')
+        anat = layout.get(modality_category="anatomical", return_type="filename")
+        func = layout.get(modality_category="functional", return_type="filename")
 
         assert len(anat) > 0
         assert len(func) > 0
@@ -88,12 +90,12 @@ class TestCustomEntities:
         n_files = len(layout.df)
         batch_ids = [i % 3 for i in range(n_files)]  # Batches 0, 1, 2
 
-        layout.add_custom_entity('batch_id', batch_ids)
+        layout.add_custom_entity("batch_id", batch_ids)
 
-        assert 'batch_id' in layout.df.columns
+        assert "batch_id" in layout.df.columns
 
         # Query with custom entity
-        batch0 = layout.get(batch_id=0, return_type='filename')
+        batch0 = layout.get(batch_id=0, return_type="filename")
         assert len(batch0) > 0
 
     def test_combine_standard_and_custom(self, layout):
@@ -103,75 +105,76 @@ class TestCustomEntities:
             pytest.skip("No subjects in dataset")
 
         # Add custom entity
-        layout.df['processing_group'] = layout.df['sub'].apply(
-            lambda x: 'group_a' if int(x) % 2 == 0 else 'group_b'
+        layout.df["processing_group"] = layout.df["sub"].apply(
+            lambda x: "group_a" if int(x) % 2 == 0 else "group_b"
         )
 
         # Query with both standard and custom
         files = layout.get(
             subject=subjects[0],
-            processing_group='group_a' if int(subjects[0]) % 2 == 0 else 'group_b',
-            return_type='filename'
+            processing_group="group_a" if int(subjects[0]) % 2 == 0 else "group_b",
+            return_type="filename",
         )
 
         assert len(files) > 0
 
     def test_overwrite_protection(self, layout):
         """Test that overwrite protection works."""
-        layout.add_custom_entity('my_entity', 'value1')
+        layout.add_custom_entity("my_entity", "value1")
 
         # Try to add again without overwrite
         with pytest.raises(ValueError, match="already exists"):
-            layout.add_custom_entity('my_entity', 'value2')
+            layout.add_custom_entity("my_entity", "value2")
 
         # Should work with overwrite=True
-        layout.add_custom_entity('my_entity', 'value2', overwrite=True)
-        assert (layout.df['my_entity'] == 'value2').all()
+        layout.add_custom_entity("my_entity", "value2", overwrite=True)
+        assert (layout.df["my_entity"] == "value2").all()
 
     def test_direct_dataframe_manipulation(self, layout):
         """Test that direct df manipulation also works for querying."""
         # Add custom entity directly (without helper method)
-        layout.df['direct_entity'] = 'direct_value'
+        layout.df["direct_entity"] = "direct_value"
 
         # Should be queryable
-        files = layout.get(direct_entity='direct_value', return_type='filename')
+        files = layout.get(direct_entity="direct_value", return_type="filename")
         assert len(files) == len(layout.df)
 
     def test_modify_existing_entity(self, layout):
         """Test modifying an existing entity value."""
         # Modify a standard entity
-        original_tasks = layout.df['task'].unique()
+        original_tasks = layout.df["task"].unique()
 
         # Recode task names
-        task_mapping = {'balloonanalogrisktask': 'BART'}
-        layout.df['task'] = layout.df['task'].replace(task_mapping)
+        task_mapping = {"balloonanalogrisktask": "BART"}
+        layout.df["task"] = layout.df["task"].replace(task_mapping)
 
         # Query with new value
-        bart_files = layout.get(task='BART', return_type='filename')
+        bart_files = layout.get(task="BART", return_type="filename")
 
         # Should have files if original had balloonanalogrisktask
-        if 'balloonanalogrisktask' in original_tasks:
+        if "balloonanalogrisktask" in original_tasks:
             assert len(bart_files) > 0
 
     def test_entity_with_subject_filter(self, layout):
         """Test custom entity combined with get_subjects filter."""
         # Add custom entity
-        layout.df['experiment_phase'] = layout.df['run'].apply(
-            lambda x: 'early' if x == '01' else 'late' if x else None
+        layout.df["experiment_phase"] = layout.df["run"].apply(
+            lambda x: "early" if x == "01" else "late" if x else None
         )
 
         # Get subjects that have early phase files
-        subjects = layout.get_subjects(experiment_phase='early')
+        subjects = layout.get_subjects(experiment_phase="early")
         assert isinstance(subjects, list)
 
     def test_none_values_in_custom_entity(self, layout):
         """Test handling of None/NaN in custom entities."""
+
         def sometimes_none(row):
             # Only set value for BOLD files
-            return 'has_value' if row['suffix'] == 'bold' else None
+            return "has_value" if row["suffix"] == "bold" else None
 
-        layout.add_custom_entity('optional_entity', sometimes_none)
+        layout.add_custom_entity("optional_entity", sometimes_none)
 
         # Query should only match non-None values
-        files = layout.get(optional_entity='has_value', return_type='filename')
-        assert all('bold' in f for f in files)
+        files = layout.get(optional_entity="has_value", return_type="filename")
+        assert all("bold" in f for f in files)

--- a/tests/pybids/test_custom_entities.py
+++ b/tests/pybids/test_custom_entities.py
@@ -1,0 +1,177 @@
+"""Tests for custom entity functionality."""
+
+import pytest
+from pathlib import Path
+import tempfile
+
+from bids2table.pybids import BIDSLayout
+
+
+@pytest.fixture
+def test_dataset():
+    """Return path to a test BIDS dataset."""
+    dataset_path = Path(__file__).parents[2] / 'bids-examples' / 'ds001'
+    if not dataset_path.exists():
+        pytest.skip(f"Test dataset not found: {dataset_path}")
+    return dataset_path
+
+
+@pytest.fixture
+def layout(test_dataset):
+    """Create a BIDSLayout for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / 'test_cache.parquet'
+        yield BIDSLayout(test_dataset, validate=False, cache_path=cache_path)
+
+
+class TestCustomEntities:
+    """Tests for adding and querying custom entities."""
+
+    def test_add_constant_value(self, layout):
+        """Test adding a constant value to all rows."""
+        layout.add_custom_entity('status', 'pending')
+
+        assert 'status' in layout.df.columns
+        assert (layout.df['status'] == 'pending').all()
+
+        # Query with custom entity
+        files = layout.get(status='pending', return_type='filename')
+        assert len(files) == len(layout.df)
+
+    def test_add_from_dict_subjects(self, layout):
+        """Test adding entity from subject mapping."""
+        subjects = layout.get_subjects()
+        if not subjects:
+            pytest.skip("No subjects in dataset")
+
+        # Create mapping for first few subjects
+        qc_mapping = {subjects[0]: 'pass', subjects[1]: 'fail'}
+        layout.add_custom_entity('qc_grade', qc_mapping)
+
+        assert 'qc_grade' in layout.df.columns
+
+        # Check values
+        sub01_rows = layout.df[layout.df['sub'] == subjects[0]]
+        assert (sub01_rows['qc_grade'] == 'pass').all()
+
+        # Query with custom entity
+        passed = layout.get(qc_grade='pass', return_type='filename')
+        failed = layout.get(qc_grade='fail', return_type='filename')
+
+        assert len(passed) > 0
+        assert len(failed) > 0
+
+    def test_add_from_function(self, layout):
+        """Test adding entity computed from function."""
+        def categorize(row):
+            if row['suffix'] in ['T1w', 'T2w', 'inplaneT2']:
+                return 'anatomical'
+            elif row['suffix'] == 'bold':
+                return 'functional'
+            else:
+                return 'other'
+
+        layout.add_custom_entity('modality_category', categorize)
+
+        assert 'modality_category' in layout.df.columns
+
+        # Query with custom entity
+        anat = layout.get(modality_category='anatomical', return_type='filename')
+        func = layout.get(modality_category='functional', return_type='filename')
+
+        assert len(anat) > 0
+        assert len(func) > 0
+
+    def test_add_from_list(self, layout):
+        """Test adding entity from list of values."""
+        # Create list matching number of files
+        n_files = len(layout.df)
+        batch_ids = [i % 3 for i in range(n_files)]  # Batches 0, 1, 2
+
+        layout.add_custom_entity('batch_id', batch_ids)
+
+        assert 'batch_id' in layout.df.columns
+
+        # Query with custom entity
+        batch0 = layout.get(batch_id=0, return_type='filename')
+        assert len(batch0) > 0
+
+    def test_combine_standard_and_custom(self, layout):
+        """Test querying with both standard and custom entities."""
+        subjects = layout.get_subjects()
+        if not subjects:
+            pytest.skip("No subjects in dataset")
+
+        # Add custom entity
+        layout.df['processing_group'] = layout.df['sub'].apply(
+            lambda x: 'group_a' if int(x) % 2 == 0 else 'group_b'
+        )
+
+        # Query with both standard and custom
+        files = layout.get(
+            subject=subjects[0],
+            processing_group='group_a' if int(subjects[0]) % 2 == 0 else 'group_b',
+            return_type='filename'
+        )
+
+        assert len(files) > 0
+
+    def test_overwrite_protection(self, layout):
+        """Test that overwrite protection works."""
+        layout.add_custom_entity('my_entity', 'value1')
+
+        # Try to add again without overwrite
+        with pytest.raises(ValueError, match="already exists"):
+            layout.add_custom_entity('my_entity', 'value2')
+
+        # Should work with overwrite=True
+        layout.add_custom_entity('my_entity', 'value2', overwrite=True)
+        assert (layout.df['my_entity'] == 'value2').all()
+
+    def test_direct_dataframe_manipulation(self, layout):
+        """Test that direct df manipulation also works for querying."""
+        # Add custom entity directly (without helper method)
+        layout.df['direct_entity'] = 'direct_value'
+
+        # Should be queryable
+        files = layout.get(direct_entity='direct_value', return_type='filename')
+        assert len(files) == len(layout.df)
+
+    def test_modify_existing_entity(self, layout):
+        """Test modifying an existing entity value."""
+        # Modify a standard entity
+        original_tasks = layout.df['task'].unique()
+
+        # Recode task names
+        task_mapping = {'balloonanalogrisktask': 'BART'}
+        layout.df['task'] = layout.df['task'].replace(task_mapping)
+
+        # Query with new value
+        bart_files = layout.get(task='BART', return_type='filename')
+
+        # Should have files if original had balloonanalogrisktask
+        if 'balloonanalogrisktask' in original_tasks:
+            assert len(bart_files) > 0
+
+    def test_entity_with_subject_filter(self, layout):
+        """Test custom entity combined with get_subjects filter."""
+        # Add custom entity
+        layout.df['experiment_phase'] = layout.df['run'].apply(
+            lambda x: 'early' if x == '01' else 'late' if x else None
+        )
+
+        # Get subjects that have early phase files
+        subjects = layout.get_subjects(experiment_phase='early')
+        assert isinstance(subjects, list)
+
+    def test_none_values_in_custom_entity(self, layout):
+        """Test handling of None/NaN in custom entities."""
+        def sometimes_none(row):
+            # Only set value for BOLD files
+            return 'has_value' if row['suffix'] == 'bold' else None
+
+        layout.add_custom_entity('optional_entity', sometimes_none)
+
+        # Query should only match non-None values
+        files = layout.get(optional_entity='has_value', return_type='filename')
+        assert all('bold' in f for f in files)

--- a/tests/pybids/test_layout.py
+++ b/tests/pybids/test_layout.py
@@ -1,11 +1,11 @@
 """Tests for BIDSLayout class."""
 
-import pytest
-from pathlib import Path
 import tempfile
-import shutil
+from pathlib import Path
 
-from bids2table.pybids import BIDSLayout, Query, BIDSFile
+import pytest
+
+from bids2table.pybids import BIDSFile, BIDSLayout, Query
 
 
 # Fixture for test dataset
@@ -13,7 +13,7 @@ from bids2table.pybids import BIDSLayout, Query, BIDSFile
 def test_dataset():
     """Return path to a test BIDS dataset."""
     # Use one of the bids-examples datasets
-    dataset_path = Path(__file__).parents[2] / 'bids-examples' / 'ds001'
+    dataset_path = Path(__file__).parents[2] / "bids-examples" / "ds001"
     if not dataset_path.exists():
         pytest.skip(f"Test dataset not found: {dataset_path}")
     return dataset_path
@@ -24,7 +24,7 @@ def layout(test_dataset):
     """Create a BIDSLayout for testing."""
     # Use temporary cache to avoid polluting test dataset
     with tempfile.TemporaryDirectory() as tmpdir:
-        cache_path = Path(tmpdir) / 'test_cache.parquet'
+        cache_path = Path(tmpdir) / "test_cache.parquet"
         yield BIDSLayout(test_dataset, validate=False, cache_path=cache_path)
 
 
@@ -34,7 +34,7 @@ class TestBIDSLayoutInit:
     def test_init_basic(self, test_dataset):
         """Test basic initialization."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            cache_path = Path(tmpdir) / 'cache.parquet'
+            cache_path = Path(tmpdir) / "cache.parquet"
             layout = BIDSLayout(test_dataset, cache_path=cache_path)
 
             assert layout.root == test_dataset.absolute()
@@ -44,7 +44,7 @@ class TestBIDSLayoutInit:
     def test_init_with_cache(self, test_dataset):
         """Test that cache is created and reused."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            cache_path = Path(tmpdir) / 'cache.parquet'
+            cache_path = Path(tmpdir) / "cache.parquet"
 
             # First initialization - creates cache
             layout1 = BIDSLayout(test_dataset, cache_path=cache_path)
@@ -60,9 +60,9 @@ class TestBIDSLayoutInit:
     def test_repr(self, layout):
         """Test string representation."""
         repr_str = repr(layout)
-        assert 'BIDSLayout' in repr_str
-        assert 'subjects=' in repr_str
-        assert 'files=' in repr_str
+        assert "BIDSLayout" in repr_str
+        assert "subjects=" in repr_str
+        assert "files=" in repr_str
 
 
 class TestBIDSLayoutGet:
@@ -70,7 +70,7 @@ class TestBIDSLayoutGet:
 
     def test_get_basic(self, layout):
         """Test basic file query."""
-        files = layout.get(return_type='filename')
+        files = layout.get(return_type="filename")
         assert isinstance(files, list)
         assert len(files) > 0
         assert all(isinstance(f, str) for f in files)
@@ -82,17 +82,17 @@ class TestBIDSLayoutGet:
             pytest.skip("No subjects in dataset")
 
         subject = subjects[0]
-        files = layout.get(subject=subject, return_type='filename')
+        files = layout.get(subject=subject, return_type="filename")
 
         assert len(files) > 0
         # Check that all files contain subject ID
-        assert all(f'sub-{subject}' in f for f in files)
+        assert all(f"sub-{subject}" in f for f in files)
 
     def test_get_by_suffix(self, layout):
         """Test filtering by suffix."""
         # Try common suffixes
-        for suffix in ['T1w', 'bold', 'events']:
-            files = layout.get(suffix=suffix, return_type='filename')
+        for suffix in ["T1w", "bold", "events"]:
+            files = layout.get(suffix=suffix, return_type="filename")
             if files:
                 # Check that files have the expected suffix
                 assert any(suffix in f for f in files)
@@ -107,11 +107,7 @@ class TestBIDSLayoutGet:
             pytest.skip("No subjects in dataset")
 
         subject = subjects[0]
-        files = layout.get(
-            subject=subject,
-            datatype='anat',
-            return_type='filename'
-        )
+        files = layout.get(subject=subject, datatype="anat", return_type="filename")
 
         # Should have filtered by both subject and datatype
         # (May be empty if subject doesn't have anat data)
@@ -119,28 +115,28 @@ class TestBIDSLayoutGet:
 
     def test_get_return_type_file(self, layout):
         """Test return_type='file' returns BIDSFile objects."""
-        files = layout.get(return_type='file')
+        files = layout.get(return_type="file")
 
         assert len(files) > 0
         assert all(isinstance(f, BIDSFile) for f in files)
 
     def test_get_return_type_filename(self, layout):
         """Test return_type='filename' returns strings."""
-        files = layout.get(return_type='filename')
+        files = layout.get(return_type="filename")
 
         assert len(files) > 0
         assert all(isinstance(f, str) for f in files)
 
     def test_get_return_type_id(self, layout):
         """Test return_type='id' returns indices."""
-        ids = layout.get(return_type='id')
+        ids = layout.get(return_type="id")
 
         assert len(ids) > 0
         assert all(isinstance(i, (int, type(ids[0]))) for i in ids)
 
     def test_get_return_type_dir(self, layout):
         """Test return_type='dir' returns unique directories."""
-        dirs = layout.get(return_type='dir')
+        dirs = layout.get(return_type="dir")
 
         assert len(dirs) > 0
         assert all(isinstance(d, str) for d in dirs)
@@ -153,29 +149,20 @@ class TestBIDSLayoutGet:
         if len(subjects) < 2:
             pytest.skip("Need at least 2 subjects")
 
-        files = layout.get(
-            subject=subjects[:2],
-            return_type='filename'
-        )
+        files = layout.get(subject=subjects[:2], return_type="filename")
 
         assert len(files) > 0
 
     def test_get_with_query_optional(self, layout):
         """Test Query.OPTIONAL allows missing entities."""
-        files = layout.get(
-            session=Query.OPTIONAL,
-            return_type='filename'
-        )
+        files = layout.get(session=Query.OPTIONAL, return_type="filename")
 
         # Should return all files regardless of session
         assert len(files) > 0
 
     def test_get_with_query_any(self, layout):
         """Test Query.ANY matches any value."""
-        files = layout.get(
-            suffix=Query.ANY,
-            return_type='filename'
-        )
+        files = layout.get(suffix=Query.ANY, return_type="filename")
 
         # Should return all files (no filtering on suffix)
         assert len(files) > 0
@@ -183,7 +170,7 @@ class TestBIDSLayoutGet:
     def test_get_invalid_return_type(self, layout):
         """Test that invalid return_type raises error."""
         with pytest.raises(ValueError, match="Unknown return_type"):
-            layout.get(return_type='invalid')
+            layout.get(return_type="invalid")
 
 
 class TestBIDSLayoutEntities:
@@ -198,12 +185,12 @@ class TestBIDSLayoutEntities:
         # Should be sorted
         assert subjects == sorted(subjects)
         # Should not have 'sub-' prefix
-        assert all(not s.startswith('sub-') for s in subjects)
+        assert all(not s.startswith("sub-") for s in subjects)
 
     def test_get_subjects_with_filter(self, layout):
         """Test filtering subjects by other entities."""
         all_subjects = layout.get_subjects()
-        filtered_subjects = layout.get_subjects(datatype='anat')
+        filtered_subjects = layout.get_subjects(datatype="anat")
 
         # Filtered should be subset (or equal)
         assert set(filtered_subjects).issubset(set(all_subjects))
@@ -216,7 +203,7 @@ class TestBIDSLayoutEntities:
         # May be empty if no sessions in dataset
         if sessions:
             assert sessions == sorted(sessions)
-            assert all(not s.startswith('ses-') for s in sessions)
+            assert all(not s.startswith("ses-") for s in sessions)
 
     def test_get_sessions_by_subject(self, layout):
         """Test getting sessions for specific subject."""
@@ -238,7 +225,7 @@ class TestBIDSLayoutMetadata:
 
     def test_get_metadata(self, layout):
         """Test loading metadata for a file."""
-        files = layout.get(suffix='bold', return_type='filename')
+        files = layout.get(suffix="bold", return_type="filename")
         if not files:
             pytest.skip("No BOLD files in dataset")
 
@@ -251,7 +238,7 @@ class TestBIDSLayoutMetadata:
 
     def test_get_file(self, layout):
         """Test getting BIDSFile object."""
-        files = layout.get(return_type='filename')
+        files = layout.get(return_type="filename")
         if not files:
             pytest.skip("No files in dataset")
 
@@ -276,8 +263,8 @@ class TestBIDSLayoutEntityMapping:
             pytest.skip("No subjects in dataset")
 
         # Both 'subject' and 'sub' should work
-        files1 = layout.get(subject=subjects[0], return_type='filename')
-        files2 = layout.get(sub=subjects[0], return_type='filename')
+        files1 = layout.get(subject=subjects[0], return_type="filename")
+        files2 = layout.get(sub=subjects[0], return_type="filename")
 
         assert set(files1) == set(files2)
 
@@ -288,16 +275,16 @@ class TestBIDSLayoutEntityMapping:
             pytest.skip("No sessions in dataset")
 
         # Both 'session' and 'ses' should work
-        files1 = layout.get(session=sessions[0], return_type='filename')
-        files2 = layout.get(ses=sessions[0], return_type='filename')
+        files1 = layout.get(session=sessions[0], return_type="filename")
+        files2 = layout.get(ses=sessions[0], return_type="filename")
 
         assert set(files1) == set(files2)
 
     def test_extension_mapping(self, layout):
         """Test that 'extension' maps to 'ext'."""
         # Both should work
-        files1 = layout.get(extension='.nii.gz', return_type='filename')
-        files2 = layout.get(ext='.nii.gz', return_type='filename')
+        files1 = layout.get(extension=".nii.gz", return_type="filename")
+        files2 = layout.get(ext=".nii.gz", return_type="filename")
 
         # Should return same files (or both empty)
         assert set(files1) == set(files2)

--- a/tests/pybids/test_layout.py
+++ b/tests/pybids/test_layout.py
@@ -1,0 +1,303 @@
+"""Tests for BIDSLayout class."""
+
+import pytest
+from pathlib import Path
+import tempfile
+import shutil
+
+from bids2table.pybids import BIDSLayout, Query, BIDSFile
+
+
+# Fixture for test dataset
+@pytest.fixture
+def test_dataset():
+    """Return path to a test BIDS dataset."""
+    # Use one of the bids-examples datasets
+    dataset_path = Path(__file__).parents[2] / 'bids-examples' / 'ds001'
+    if not dataset_path.exists():
+        pytest.skip(f"Test dataset not found: {dataset_path}")
+    return dataset_path
+
+
+@pytest.fixture
+def layout(test_dataset):
+    """Create a BIDSLayout for testing."""
+    # Use temporary cache to avoid polluting test dataset
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_path = Path(tmpdir) / 'test_cache.parquet'
+        yield BIDSLayout(test_dataset, validate=False, cache_path=cache_path)
+
+
+class TestBIDSLayoutInit:
+    """Tests for BIDSLayout initialization."""
+
+    def test_init_basic(self, test_dataset):
+        """Test basic initialization."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'cache.parquet'
+            layout = BIDSLayout(test_dataset, cache_path=cache_path)
+
+            assert layout.root == test_dataset.absolute()
+            assert layout.df is not None
+            assert len(layout.df) > 0
+
+    def test_init_with_cache(self, test_dataset):
+        """Test that cache is created and reused."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / 'cache.parquet'
+
+            # First initialization - creates cache
+            layout1 = BIDSLayout(test_dataset, cache_path=cache_path)
+            assert cache_path.exists()
+            n_files_1 = len(layout1.df)
+
+            # Second initialization - uses cache
+            layout2 = BIDSLayout(test_dataset, cache_path=cache_path)
+            n_files_2 = len(layout2.df)
+
+            assert n_files_1 == n_files_2
+
+    def test_repr(self, layout):
+        """Test string representation."""
+        repr_str = repr(layout)
+        assert 'BIDSLayout' in repr_str
+        assert 'subjects=' in repr_str
+        assert 'files=' in repr_str
+
+
+class TestBIDSLayoutGet:
+    """Tests for BIDSLayout.get() method."""
+
+    def test_get_basic(self, layout):
+        """Test basic file query."""
+        files = layout.get(return_type='filename')
+        assert isinstance(files, list)
+        assert len(files) > 0
+        assert all(isinstance(f, str) for f in files)
+
+    def test_get_by_subject(self, layout):
+        """Test filtering by subject."""
+        subjects = layout.get_subjects()
+        if not subjects:
+            pytest.skip("No subjects in dataset")
+
+        subject = subjects[0]
+        files = layout.get(subject=subject, return_type='filename')
+
+        assert len(files) > 0
+        # Check that all files contain subject ID
+        assert all(f'sub-{subject}' in f for f in files)
+
+    def test_get_by_suffix(self, layout):
+        """Test filtering by suffix."""
+        # Try common suffixes
+        for suffix in ['T1w', 'bold', 'events']:
+            files = layout.get(suffix=suffix, return_type='filename')
+            if files:
+                # Check that files have the expected suffix
+                assert any(suffix in f for f in files)
+                break
+        else:
+            pytest.skip("No files with common suffixes found")
+
+    def test_get_multiple_filters(self, layout):
+        """Test filtering by multiple entities."""
+        subjects = layout.get_subjects()
+        if not subjects:
+            pytest.skip("No subjects in dataset")
+
+        subject = subjects[0]
+        files = layout.get(
+            subject=subject,
+            datatype='anat',
+            return_type='filename'
+        )
+
+        # Should have filtered by both subject and datatype
+        # (May be empty if subject doesn't have anat data)
+        assert isinstance(files, list)
+
+    def test_get_return_type_file(self, layout):
+        """Test return_type='file' returns BIDSFile objects."""
+        files = layout.get(return_type='file')
+
+        assert len(files) > 0
+        assert all(isinstance(f, BIDSFile) for f in files)
+
+    def test_get_return_type_filename(self, layout):
+        """Test return_type='filename' returns strings."""
+        files = layout.get(return_type='filename')
+
+        assert len(files) > 0
+        assert all(isinstance(f, str) for f in files)
+
+    def test_get_return_type_id(self, layout):
+        """Test return_type='id' returns indices."""
+        ids = layout.get(return_type='id')
+
+        assert len(ids) > 0
+        assert all(isinstance(i, (int, type(ids[0]))) for i in ids)
+
+    def test_get_return_type_dir(self, layout):
+        """Test return_type='dir' returns unique directories."""
+        dirs = layout.get(return_type='dir')
+
+        assert len(dirs) > 0
+        assert all(isinstance(d, str) for d in dirs)
+        # Should be unique
+        assert len(dirs) == len(set(dirs))
+
+    def test_get_with_list_values(self, layout):
+        """Test filtering with list of values."""
+        subjects = layout.get_subjects()
+        if len(subjects) < 2:
+            pytest.skip("Need at least 2 subjects")
+
+        files = layout.get(
+            subject=subjects[:2],
+            return_type='filename'
+        )
+
+        assert len(files) > 0
+
+    def test_get_with_query_optional(self, layout):
+        """Test Query.OPTIONAL allows missing entities."""
+        files = layout.get(
+            session=Query.OPTIONAL,
+            return_type='filename'
+        )
+
+        # Should return all files regardless of session
+        assert len(files) > 0
+
+    def test_get_with_query_any(self, layout):
+        """Test Query.ANY matches any value."""
+        files = layout.get(
+            suffix=Query.ANY,
+            return_type='filename'
+        )
+
+        # Should return all files (no filtering on suffix)
+        assert len(files) > 0
+
+    def test_get_invalid_return_type(self, layout):
+        """Test that invalid return_type raises error."""
+        with pytest.raises(ValueError, match="Unknown return_type"):
+            layout.get(return_type='invalid')
+
+
+class TestBIDSLayoutEntities:
+    """Tests for entity extraction methods."""
+
+    def test_get_subjects(self, layout):
+        """Test getting subject list."""
+        subjects = layout.get_subjects()
+
+        assert isinstance(subjects, list)
+        assert len(subjects) > 0
+        # Should be sorted
+        assert subjects == sorted(subjects)
+        # Should not have 'sub-' prefix
+        assert all(not s.startswith('sub-') for s in subjects)
+
+    def test_get_subjects_with_filter(self, layout):
+        """Test filtering subjects by other entities."""
+        all_subjects = layout.get_subjects()
+        filtered_subjects = layout.get_subjects(datatype='anat')
+
+        # Filtered should be subset (or equal)
+        assert set(filtered_subjects).issubset(set(all_subjects))
+
+    def test_get_sessions(self, layout):
+        """Test getting session list."""
+        sessions = layout.get_sessions()
+
+        assert isinstance(sessions, list)
+        # May be empty if no sessions in dataset
+        if sessions:
+            assert sessions == sorted(sessions)
+            assert all(not s.startswith('ses-') for s in sessions)
+
+    def test_get_sessions_by_subject(self, layout):
+        """Test getting sessions for specific subject."""
+        subjects = layout.get_subjects()
+        if not subjects:
+            pytest.skip("No subjects in dataset")
+
+        subject = subjects[0]
+        sessions = layout.get_sessions(subject=subject)
+
+        assert isinstance(sessions, list)
+        # Sessions should be subset of all sessions
+        all_sessions = layout.get_sessions()
+        assert set(sessions).issubset(set(all_sessions))
+
+
+class TestBIDSLayoutMetadata:
+    """Tests for metadata access."""
+
+    def test_get_metadata(self, layout):
+        """Test loading metadata for a file."""
+        files = layout.get(suffix='bold', return_type='filename')
+        if not files:
+            pytest.skip("No BOLD files in dataset")
+
+        file_path = files[0]
+        metadata = layout.get_metadata(file_path)
+
+        assert isinstance(metadata, dict)
+        # BOLD files typically have RepetitionTime
+        # (but not guaranteed in all test datasets)
+
+    def test_get_file(self, layout):
+        """Test getting BIDSFile object."""
+        files = layout.get(return_type='filename')
+        if not files:
+            pytest.skip("No files in dataset")
+
+        file_path = files[0]
+        bids_file = layout.get_file(file_path)
+
+        assert isinstance(bids_file, BIDSFile)
+        assert bids_file.path == file_path
+
+        # Can get entities
+        entities = bids_file.get_entities()
+        assert isinstance(entities, dict)
+
+
+class TestBIDSLayoutEntityMapping:
+    """Tests for PyBIDS entity name mapping."""
+
+    def test_subject_mapping(self, layout):
+        """Test that 'subject' maps to 'sub'."""
+        subjects = layout.get_subjects()
+        if not subjects:
+            pytest.skip("No subjects in dataset")
+
+        # Both 'subject' and 'sub' should work
+        files1 = layout.get(subject=subjects[0], return_type='filename')
+        files2 = layout.get(sub=subjects[0], return_type='filename')
+
+        assert set(files1) == set(files2)
+
+    def test_session_mapping(self, layout):
+        """Test that 'session' maps to 'ses'."""
+        sessions = layout.get_sessions()
+        if not sessions:
+            pytest.skip("No sessions in dataset")
+
+        # Both 'session' and 'ses' should work
+        files1 = layout.get(session=sessions[0], return_type='filename')
+        files2 = layout.get(ses=sessions[0], return_type='filename')
+
+        assert set(files1) == set(files2)
+
+    def test_extension_mapping(self, layout):
+        """Test that 'extension' maps to 'ext'."""
+        # Both should work
+        files1 = layout.get(extension='.nii.gz', return_type='filename')
+        files2 = layout.get(ext='.nii.gz', return_type='filename')
+
+        # Should return same files (or both empty)
+        assert set(files1) == set(files2)

--- a/tests/pybids/test_query.py
+++ b/tests/pybids/test_query.py
@@ -1,0 +1,25 @@
+"""Tests for Query class."""
+
+import pytest
+from bids2table.pybids import Query
+
+
+def test_query_sentinels_are_unique():
+    """Test that Query sentinel values are distinct objects."""
+    assert Query.OPTIONAL is not Query.NONE
+    assert Query.OPTIONAL is not Query.ANY
+    assert Query.NONE is not Query.ANY
+
+
+def test_query_sentinels_are_singletons():
+    """Test that Query sentinels are the same object across imports."""
+    from bids2table.pybids import Query as Query2
+
+    assert Query.OPTIONAL is Query2.OPTIONAL
+    assert Query.NONE is Query2.NONE
+    assert Query.ANY is Query2.ANY
+
+
+def test_query_repr():
+    """Test Query string representation."""
+    assert repr(Query()) == "Query"

--- a/tests/pybids/test_query.py
+++ b/tests/pybids/test_query.py
@@ -1,6 +1,5 @@
 """Tests for Query class."""
 
-import pytest
 from bids2table.pybids import Query
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,9 @@ dependencies = [
 cloud = [
     { name = "cloudpathlib", extra = ["gs", "s3"] },
 ]
+pybids = [
+    { name = "pandas" },
+]
 s3 = [
     { name = "cloudpathlib", extra = ["s3"] },
 ]
@@ -54,10 +57,11 @@ requires-dist = [
     { name = "bidsschematools", specifier = ">=1.0" },
     { name = "cloudpathlib", extras = ["gs", "s3"], marker = "extra == 'cloud'", specifier = ">=0.21.0" },
     { name = "cloudpathlib", extras = ["s3"], marker = "extra == 's3'", specifier = ">=0.21.0" },
+    { name = "pandas", marker = "extra == 'pybids'", specifier = ">=2.0.0" },
     { name = "pyarrow", specifier = ">=24.0.0" },
     { name = "tqdm", specifier = ">=4.67.3" },
 ]
-provides-extras = ["cloud", "s3"]
+provides-extras = ["cloud", "s3", "pybids"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This is the PR that captures and migrates the development taken place at the nipreps hackathon in [this](https://github.com/childmindresearch/b2t-pybids) repository. A usage guide showing the compatibility with `pybids.BIDSLayout` can be found here: https://childmindresearch.github.io/b2t-pybids/.

In particular, the approach taken here:
* Crawled popular repositories that use `pybids` to identify the common patterns we should expose and support.
* Implemented a thin wrapper around the native `b2t` table structure that provides the same convenience utilities, allowing a drop-in replacement for the vast majority of users.