### PR TITLE
feat: Allow schema paths/objects to be passed to API functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # bids2table
+
 [![CI](https://github.com/childmindresearch/bids2table/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/childmindresearch/bids2table/actions/workflows/ci.yaml?query=branch%3Amain)
 [![Docs](https://github.com/childmindresearch/bids2table/actions/workflows/docs.yaml/badge.svg?branch=main)](https://childmindresearch.github.io/bids2table/bids2table)
 [![codecov](https://codecov.io/gh/childmindresearch/bids2table/branch/main/graph/badge.svg?token=22HWWFWPW5)](https://codecov.io/gh/childmindresearch/bids2table)
@@ -111,7 +112,6 @@ As an example, here we index all datasets on [OpenNeuro](https://openneuro.org/)
 
 Using 8 threads, we can index all ~1400 OpenNeuro datasets (1.2M files) in less than 15 minutes.
 
-
 ### Indexing datasets from python
 
 You can also index datasets using the Python API.
@@ -140,3 +140,27 @@ pq.write_table(tab, "ds000224.parquet")
 # Convert to a pandas dataframe.
 df = tab.to_pandas(types_mapper=pd.ArrowDtype)
 ```
+
+### Indexing with a custom BIDS schema
+
+By default, `bids2table` uses the BIDS schema bundled with `bidsschematools`.
+Pass a `schema=` argument to `index_dataset`, `batch_index_dataset`,
+`get_arrow_schema`, `get_column_names`, or `validate_bids_entities` to use a
+different schema. The argument may be a path to a schema directory, a string
+URI accepted by `bidsschematools.schema.load_schema`, or a pre-loaded
+`bidsschematools.types.Namespace`.
+
+```python
+import bidsschematools.schema
+import bids2table as b2t2
+
+# Use a pre-loaded schema (e.g. when indexing several datasets that share one).
+schema = bidsschematools.schema.load_schema()
+tab = b2t2.index_dataset("bids-examples/ds102", schema=schema)
+
+# Or pass a path to a custom schema directory.
+tab = b2t2.index_dataset("/data/ds001", schema="/path/to/custom-schema")
+```
+
+Different `schema` arguments may be used for different calls within the same
+process; per-call schemas propagate to worker processes when `max_workers > 0`.

--- a/bids2table/__init__.py
+++ b/bids2table/__init__.py
@@ -8,9 +8,6 @@ __all__ = [
     "get_column_names",
     "parse_bids_entities",
     "validate_bids_entities",
-    "set_bids_schema",
-    "get_bids_schema",
-    "get_bids_entity_arrow_schema",
     "format_bids_path",
     "load_bids_metadata",
     "cloudpathlib_is_available",
@@ -24,10 +21,7 @@ if importlib.util.find_spec("pandas"):
 
 from ._entities import (
     format_bids_path,
-    get_bids_entity_arrow_schema,
-    get_bids_schema,
     parse_bids_entities,
-    set_bids_schema,
     validate_bids_entities,
 )
 from ._indexing import (

--- a/bids2table/__init__.py
+++ b/bids2table/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "format_bids_path",
     "load_bids_metadata",
     "cloudpathlib_is_available",
+    "SchemaSpec",
 ]
 
 import importlib.util
@@ -38,4 +39,5 @@ from ._indexing import (
 )
 from ._metadata import load_bids_metadata
 from ._pathlib import cloudpathlib_is_available
+from ._schema import SchemaSpec
 from ._version import *

--- a/bids2table/_entities.py
+++ b/bids2table/_entities.py
@@ -14,6 +14,7 @@ import pyarrow as pa
 from bidsschematools.types import Namespace
 
 from ._logging import setup_logger
+from ._schema import decode_metadata
 
 BIDSValue = str | int
 
@@ -242,6 +243,27 @@ def validate_bids_entities(
             extra_entities[name] = value
 
     return valid_entities, extra_entities
+
+
+@lru_cache
+def _lookups_from_arrow(
+    pa_schema: pa.Schema,
+) -> tuple[dict[str, str], dict[str, dict[str, Any]]]:
+    """Reconstruct (name_entity_map, entity_schema) from a `pa.Schema`.
+
+    Used inside `_pyarrow_validate_entities`. Filters out non-entity fields
+    (those without an "entity" key in their decoded metadata). `pa.Schema`
+    is hashable, so `lru_cache` keys correctly. The cache lives in the
+    worker process; one field-walk per worker per distinct schema.
+    """
+    name_entity_map: dict[str, str] = {}
+    entity_schema: dict[str, dict[str, Any]] = {}
+    for field in pa_schema:
+        meta = decode_metadata(field.metadata or {})
+        if long_entity := meta.pop("entity", None):
+            name_entity_map[field.name] = long_entity
+            entity_schema[long_entity] = meta
+    return name_entity_map, entity_schema
 
 
 def format_bids_path(entities: dict[str, Any], int_format: str = "%d") -> Path:

--- a/bids2table/_entities.py
+++ b/bids2table/_entities.py
@@ -3,15 +3,12 @@
 Uses the BIDS schema for validation.
 """
 
-import json
 import re
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-import bidsschematools.schema
 import pyarrow as pa
-from bidsschematools.types import Namespace
 
 from ._logging import setup_logger
 from ._schema import (
@@ -22,48 +19,6 @@ from ._schema import (
 )
 
 BIDSValue = str | int
-
-# Global BIDS schema namespace.
-_BIDS_SCHEMA: Namespace
-# Map of entity names to schema metadata.
-_BIDS_ENTITY_SCHEMA: dict[str, dict[str, Any]]
-# Map of BIDS short names (e.g. 'sub') to long entities ('subject').
-_BIDS_NAME_ENTITY_MAP: dict[str, str]
-
-# BIDS schema in Arrow format
-_BIDS_ENTITY_ARROW_SCHEMA: pa.Schema
-
-# "Special" entities that are part of the BIDS file name spec but not in the BIDS schema
-# (bc they don't follow the '{key}-{value}' format).
-_BIDS_SPECIAL_ENTITY_SCHEMA = {
-    "datatype": {
-        "name": "datatype",
-        "display_name": "Data type",
-        "description": "A functional group of different types of data.",
-        "type": "string",
-        "format": "special",
-    },
-    "suffix": {
-        "name": "suffix",
-        "display_name": "Suffix",
-        "description": "Final part of file name after final '_' and before extension.",
-        "type": "string",
-        "format": "special",
-    },
-    "extension": {
-        "name": "ext",
-        "display_name": "File extension",
-        "description": "Full file extension after the left-most period.",
-        "type": "string",
-        "format": "special",
-    },
-}
-
-_BIDS_FORMAT_ARROW_DTYPE_MAP = {
-    "index": pa.int32(),
-    "label": pa.string(),
-    "special": pa.string(),
-}
 
 _BIDS_FORMAT_PY_TYPE_MAP = {
     "index": int,
@@ -78,66 +33,6 @@ _BIDS_DATATYPE_PATTERN = re.compile(
 )
 
 _logger = setup_logger(__package__)
-
-
-def set_bids_schema(path: str | Path | None = None) -> None:
-    """Set the BIDS schema."""
-    global _BIDS_SCHEMA, _BIDS_ENTITY_SCHEMA, _BIDS_NAME_ENTITY_MAP
-    global _BIDS_ENTITY_ARROW_SCHEMA
-
-    schema = bidsschematools.schema.load_schema(path)
-    entity_schema = {
-        entity: schema.objects.entities[entity].to_dict()
-        for entity in schema.rules.entities
-    }
-    # Also include special extra entities (datatype, suffix, extension).
-    entity_schema.update(_BIDS_SPECIAL_ENTITY_SCHEMA)
-    name_entity_map = {cfg["name"]: entity for entity, cfg in entity_schema.items()}
-
-    _BIDS_SCHEMA = schema
-    _BIDS_ENTITY_SCHEMA = entity_schema
-    _BIDS_NAME_ENTITY_MAP = name_entity_map
-
-    _BIDS_ENTITY_ARROW_SCHEMA = _bids_entity_arrow_schema(
-        entity_schema,
-        bids_version=schema["bids_version"],
-        schema_version=schema["schema_version"],
-    )
-
-
-def _bids_entity_arrow_schema(
-    entity_schema: dict[str, dict[str, Any]],
-    bids_version: str,
-    schema_version: str,
-) -> pa.Schema:
-    """Create Arrow schema from BIDS entity schema."""
-    fields = []
-    for entity, cfg in entity_schema.items():
-        # Use short entity name (e.g. sub) as the field name.
-        name = cfg["name"]
-        dtype = _BIDS_FORMAT_ARROW_DTYPE_MAP[cfg["format"]]
-        # Insert full entity name (e.g. subject) into metadata.
-        metadata = {"entity": entity}
-        metadata.update(
-            {k: v if isinstance(v, str) else json.dumps(v) for k, v in cfg.items()}
-        )
-
-        field = pa.field(name, dtype, metadata=metadata)
-        fields.append(field)
-
-    metadata = {"bids_version": bids_version, "schema_version": schema_version}
-    arrow_schema = pa.schema(fields, metadata=metadata)
-    return arrow_schema
-
-
-def get_bids_schema() -> Namespace:
-    """Get the current BIDS schema."""
-    return _BIDS_SCHEMA
-
-
-def get_bids_entity_arrow_schema() -> pa.Schema:
-    """Get the current BIDS entity schema in Arrow format."""
-    return _BIDS_ENTITY_ARROW_SCHEMA
 
 
 def parse_bids_entities(path: str | Path) -> dict[str, str]:
@@ -317,7 +212,3 @@ def format_bids_path(entities: dict[str, Any], int_format: str = "%d") -> Path:
         path = f"ses-{ses}" / path
     path = f"sub-{entities['sub']}" / path
     return path
-
-
-# Initialize the default BIDS schema.
-set_bids_schema()

--- a/bids2table/_entities.py
+++ b/bids2table/_entities.py
@@ -14,7 +14,12 @@ import pyarrow as pa
 from bidsschematools.types import Namespace
 
 from ._logging import setup_logger
-from ._schema import decode_metadata
+from ._schema import (
+    SchemaSpec,
+    decode_metadata,
+    entity_arrow_schema,
+    load_bids_schema,
+)
 
 BIDSValue = str | int
 
@@ -196,30 +201,42 @@ def _parse_bids_datatype(path: Path) -> str | None:
 
 def validate_bids_entities(
     entities: dict[str, Any],
+    *,
+    schema: SchemaSpec = None,
 ) -> tuple[dict[str, BIDSValue], dict[str, Any]]:
-    """Validate BIDS entities.
-
-    Validates the type and allowed values of each entity against the BIDS schema.
+    """Validate BIDS entities against a BIDS schema.
 
     Args:
         entities: dict mapping BIDS keys to unvalidated entities
+        schema: optional `SchemaSpec` (`Namespace | str | PathT | None`).
+            `None` uses the default BIDS schema bundled with bidsschematools.
 
     Returns:
-        A tuple of `(valid_entities, extra_entities)`, where `valid_entities` is a
-            mapping of valid BIDS keys to type-casted values, and `extra_entities` a
-            mapping of any leftover entity mappings that didn't match a known entity or
-            failed validation.
+        `(valid_entities, extra_entities)` — valid entities cast to the
+        declared type, plus any leftover entries that did not match a
+        known entity or failed validation.
     """
-    valid_entities = {}
-    extra_entities = {}
+    adapter = load_bids_schema(schema)
+    pa_schema = entity_arrow_schema(adapter)
+    return _pyarrow_validate_entities(entities, pa_schema=pa_schema)
+
+
+def _pyarrow_validate_entities(
+    entities: dict[str, Any],
+    *,
+    pa_schema: pa.Schema,
+) -> tuple[dict[str, BIDSValue], dict[str, Any]]:
+    """Pyarrow-tier validation. Workers call this directly with a `pa.Schema`."""
+    name_to_entity, entity_cfg = _lookups_from_arrow(pa_schema)
+    valid_entities: dict[str, BIDSValue] = {}
+    extra_entities: dict[str, Any] = {}
 
     for name, value in entities.items():
-        if name in _BIDS_NAME_ENTITY_MAP:
-            entity = _BIDS_NAME_ENTITY_MAP[name]
-            cfg = _BIDS_ENTITY_SCHEMA[entity]
+        if name in name_to_entity:
+            entity = name_to_entity[name]
+            cfg = entity_cfg[entity]
             typ = _BIDS_FORMAT_PY_TYPE_MAP[cfg["format"]]
 
-            # Cast to target type.
             try:
                 value = typ(value)
             except ValueError:
@@ -229,7 +246,6 @@ def validate_bids_entities(
                 extra_entities[name] = value
                 continue
 
-            # Check allowed values.
             if "enum" in cfg and value not in cfg["enum"]:
                 _logger.warning(
                     f"Value {value} for entity '{name}' isn't one of the "

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -19,7 +19,7 @@ from tqdm import tqdm
 
 from ._entities import (
     _cache_parse_bids_entities,
-    validate_bids_entities,
+    _pyarrow_validate_entities,
 )
 from ._logging import setup_logger
 from ._pathlib import CloudPath, PathT, as_path, cloudpathlib_is_available
@@ -196,6 +196,8 @@ def index_dataset(
     root: str | PathT,
     include_subjects: str | list[str] | None = None,
     show_progress: bool = False,
+    *,
+    schema: SchemaSpec = None,
 ) -> pa.Table:
     """Index a BIDS dataset.
 
@@ -204,29 +206,31 @@ def index_dataset(
         include_subjects: Glob pattern or list of patterns for matching subjects to
             include in the index.
         show_progress: Show progress bar.
+        schema: BIDS schema specification to use. If ``None``, uses the bundled
+            default schema.
 
     Returns:
         An Arrow table index of the BIDS dataset.
     """
     root = as_path(root)
 
-    schema = get_arrow_schema()
+    arrow_schema = get_arrow_schema(schema=schema)
 
     dataset, _ = _get_bids_dataset(root)
     if dataset is None:
         _logger.warning(f"Path {root} is not a valid BIDS dataset directory.")
-        return pa.Table.from_pylist([], schema=schema)
+        return pa.Table.from_pylist([], schema=arrow_schema)
 
     subject_dirs = _find_bids_subject_dirs(root, include_subjects)
     subject_dirs = sorted(subject_dirs, key=lambda p: p.name)
     if len(subject_dirs) == 0:
         _logger.warning(f"Path {root} contains no matching subject dirs.")
-        return pa.Table.from_pylist([], schema=schema)
+        return pa.Table.from_pylist([], schema=arrow_schema)
 
     tables = []
     file_count = 0
     for sub in subject_dirs:
-        _, table = _index_bids_subject_dir(sub, schema=schema, dataset=dataset)
+        _, table = _index_bids_subject_dir(sub, schema=arrow_schema, dataset=dataset)
         tables.append(table)
         file_count += len(table)
     table = pa.concat_tables(tables).combine_chunks()
@@ -390,7 +394,9 @@ def _index_bids_subject_dir(
     for p in paths:
         if _is_bids_file(p):
             entities = _cache_parse_bids_entities(p)
-            valid_entities, extra_entities = validate_bids_entities(entities)
+            valid_entities, extra_entities = _pyarrow_validate_entities(
+                entities, pa_schema=schema
+            )
             record = {
                 "dataset": dataset,
                 **valid_entities,

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -19,11 +19,11 @@ from tqdm import tqdm
 
 from ._entities import (
     _cache_parse_bids_entities,
-    get_bids_entity_arrow_schema,
     validate_bids_entities,
 )
 from ._logging import setup_logger
 from ._pathlib import CloudPath, PathT, as_path, cloudpathlib_is_available
+from ._schema import SchemaSpec, entity_arrow_schema, load_bids_schema
 
 _BIDS_SUBJECT_DIR_PATTERN = re.compile(r"sub-[a-zA-Z0-9]+")
 
@@ -88,9 +88,10 @@ _INDEX_ARROW_FIELDS = {
 _logger = setup_logger(__package__)
 
 
-def get_arrow_schema() -> pa.Schema:
+def get_arrow_schema(*, schema: SchemaSpec = None) -> pa.Schema:
     """Get Arrow schema of the BIDS dataset index."""
-    entity_schema = get_bids_entity_arrow_schema()
+    adapter = load_bids_schema(schema)
+    entity_schema = entity_arrow_schema(adapter)
     index_fields = {
         name: pa.field(name, cfg["dtype"], metadata=cfg["metadata"])
         for name, cfg in _INDEX_ARROW_FIELDS.items()
@@ -102,25 +103,23 @@ def get_arrow_schema() -> pa.Schema:
         index_fields["root"],
         index_fields["path"],
     ]
-
     metadata = {
         **entity_schema.metadata,
-        "bids2table_version": importlib.metadata.version(__package__),
+        b"bids2table_version": importlib.metadata.version(__package__).encode(),
     }
-    schema = pa.schema(fields, metadata=metadata)
-    return schema
+    return pa.schema(fields, metadata=metadata)
 
 
-def get_column_names() -> enum.StrEnum:
+def get_column_names(*, schema: SchemaSpec = None) -> enum.StrEnum:
     """Get an enum of the BIDS index columns."""
     # TODO: It might be nice if the column names were statically available. One option
     # would be to generate a static _schema.py module at install time (similar to how
     # _version.py is generated) which defines the static default schema and column
     # names.
-    schema = get_arrow_schema()
+    arrow_schema = get_arrow_schema(schema=schema)
     items = []
-    for f in schema:
-        name = f.metadata["name".encode()].decode()
+    for f in arrow_schema:
+        name = f.metadata[b"name"].decode()
         items.append((name, name))
 
     BIDSColumn = enum.StrEnum("BIDSColumn", items)

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -242,6 +242,8 @@ def batch_index_dataset(
     max_workers: int | None = 0,
     executor_cls: type[Executor] = ProcessPoolExecutor,
     show_progress: bool = False,
+    *,
+    schema: SchemaSpec = None,
 ) -> Generator[pa.Table, None, None]:
     """Index a batch of BIDS datasets.
 
@@ -253,14 +255,16 @@ def batch_index_dataset(
             `concurrent.futures.ProcessPoolExecutor` for details.
         executor_cls: Executor class to use for parallel indexing.
         show_progress: Show progress bar.
+        schema: Optional `SchemaSpec`. `None` uses the default BIDS schema.
 
     Yields:
         An Arrow table index for each BIDS dataset.
     """
+    func = partial(_batch_index_func, schema=schema)
     file_count = 0
     for dataset, table in (
         pbar := tqdm(
-            _pmap(_batch_index_func, roots, max_workers, executor_cls=executor_cls),
+            _pmap(func, roots, max_workers, executor_cls=executor_cls),
             total=len(roots) if isinstance(roots, Sequence) else None,
             disable=show_progress not in {True, "dataset"},
         )
@@ -270,9 +274,11 @@ def batch_index_dataset(
         yield table
 
 
-def _batch_index_func(root: str | PathT) -> tuple[str | None, pa.Table]:
+def _batch_index_func(
+    root: str | PathT, *, schema: SchemaSpec = None
+) -> tuple[str | None, pa.Table]:
     dataset, _ = _get_bids_dataset(root)
-    table = index_dataset(root, show_progress=False)
+    table = index_dataset(root, show_progress=False, schema=schema)
     return dataset, table
 
 

--- a/bids2table/_schema.py
+++ b/bids2table/_schema.py
@@ -10,6 +10,8 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
+from bidsschematools.types import Namespace
+
 
 def encode_metadata(metadata: dict[str, Any]) -> dict[bytes, bytes]:
     """Encode a metadata dict for use as `pa.field(metadata=...)`.
@@ -62,3 +64,42 @@ class BIDSSchemaAdapter:
     bids_version: str
     schema_version: str
     entity_schema: dict[str, dict[str, Any]] = field(hash=False)
+
+
+_BIDS_SPECIAL_ENTITY_SCHEMA: dict[str, dict[str, Any]] = {
+    "datatype": {
+        "name": "datatype",
+        "display_name": "Data type",
+        "description": "A functional group of different types of data.",
+        "type": "string",
+        "format": "special",
+    },
+    "suffix": {
+        "name": "suffix",
+        "display_name": "Suffix",
+        "description": "Final part of file name after final '_' and before extension.",
+        "type": "string",
+        "format": "special",
+    },
+    "extension": {
+        "name": "ext",
+        "display_name": "File extension",
+        "description": "Full file extension after the left-most period.",
+        "type": "string",
+        "format": "special",
+    },
+}
+
+
+def _build_adapter_from_namespace(schema: Namespace) -> BIDSSchemaAdapter:
+    """Build a `BIDSSchemaAdapter` from a loaded `bidsschematools` Namespace."""
+    entity_schema = {
+        entity: schema.objects.entities[entity].to_dict()
+        for entity in schema.rules.entities
+    }
+    entity_schema.update(_BIDS_SPECIAL_ENTITY_SCHEMA)
+    return BIDSSchemaAdapter(
+        bids_version=schema["bids_version"],
+        schema_version=schema["schema_version"],
+        entity_schema=entity_schema,
+    )

--- a/bids2table/_schema.py
+++ b/bids2table/_schema.py
@@ -1,0 +1,45 @@
+"""BIDS schema adapter and pyarrow-metadata round-trip utilities.
+
+This module owns the loading and representation of the BIDS schema for
+the rest of bids2table. See
+docs/superpowers/specs/2026-05-03-bids-schema-adapter-design.md for the
+full design.
+"""
+
+import json
+from typing import Any
+
+
+def encode_metadata(metadata: dict[str, Any]) -> dict[bytes, bytes]:
+    """Encode a metadata dict for use as `pa.field(metadata=...)`.
+
+    String values are stored verbatim (encoded to bytes). Non-string
+    values are JSON-encoded then encoded to bytes.
+    """
+    return {
+        k.encode(): (v if isinstance(v, str) else json.dumps(v)).encode()
+        for k, v in metadata.items()
+    }
+
+
+def decode_metadata(metadata: dict[bytes, bytes]) -> dict[str, Any]:
+    """Inverse of `encode_metadata`.
+
+    For each value, attempts `json.loads` and falls back to the literal
+    decoded string. Round-trips correctly for every value type used by
+    bids2table's entity-config metadata in practice (`name`, `entity`,
+    `format`, `enum`, `description`, `display_name`).
+
+    Caveat: a `str` value that happens to be valid JSON (e.g. literal
+    "true", "null", or a bare numeric string) decodes to the parsed JSON
+    value rather than the original string. None of the BIDS entity-config
+    fields hit that case.
+    """
+    out: dict[str, Any] = {}
+    for k, v in metadata.items():
+        s = v.decode()
+        try:
+            out[k.decode()] = json.loads(s)
+        except json.JSONDecodeError:
+            out[k.decode()] = s
+    return out

--- a/bids2table/_schema.py
+++ b/bids2table/_schema.py
@@ -13,6 +13,7 @@ from functools import lru_cache
 from typing import Any, TypeAlias
 
 import bidsschematools.schema
+import pyarrow as pa
 from bidsschematools.types import Namespace
 
 from bids2table._pathlib import PathT
@@ -135,3 +136,33 @@ def load_bids_schema(spec: SchemaSpec = None) -> BIDSSchemaAdapter:
     raise TypeError(
         f"schema must be Namespace | str | PathT | None, got {type(spec).__name__}"
     )
+
+
+_BIDS_FORMAT_ARROW_DTYPE_MAP: dict[str, pa.DataType] = {
+    "index": pa.int32(),
+    "label": pa.string(),
+    "special": pa.string(),
+}
+
+
+@lru_cache
+def entity_arrow_schema(adapter: BIDSSchemaAdapter) -> pa.Schema:
+    """Construct a `pa.Schema` of the BIDS entity columns from `adapter`.
+
+    Per-field metadata carries the long entity name and the entity config
+    so that workers receiving only `pa.Schema` can reconstruct the lookups
+    they need (see `_lookups_from_arrow` in _entities.py).
+    """
+    fields = []
+    for entity, cfg in adapter.entity_schema.items():
+        name = cfg["name"]
+        dtype = _BIDS_FORMAT_ARROW_DTYPE_MAP[cfg["format"]]
+        metadata = encode_metadata({"entity": entity, **cfg})
+        fields.append(pa.field(name, dtype, metadata=metadata))
+    schema_metadata = encode_metadata(
+        {
+            "bids_version": adapter.bids_version,
+            "schema_version": adapter.schema_version,
+        }
+    )
+    return pa.schema(fields, metadata=schema_metadata)

--- a/bids2table/_schema.py
+++ b/bids2table/_schema.py
@@ -10,7 +10,7 @@ import json
 import os
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any
+from typing import Any, TypeAlias
 
 import bidsschematools.schema
 from bidsschematools.types import Namespace
@@ -110,6 +110,9 @@ def _build_adapter_from_namespace(schema: Namespace) -> BIDSSchemaAdapter:
     )
 
 
+SchemaSpec: TypeAlias = Namespace | str | PathT | None
+
+
 @lru_cache
 def _load_from_path(path: str | PathT | None) -> BIDSSchemaAdapter:
     """Load and cache a BIDSSchemaAdapter from a path or the default schema."""
@@ -117,7 +120,7 @@ def _load_from_path(path: str | PathT | None) -> BIDSSchemaAdapter:
     return _build_adapter_from_namespace(schema)
 
 
-def load_bids_schema(spec=None) -> BIDSSchemaAdapter:
+def load_bids_schema(spec: SchemaSpec = None) -> BIDSSchemaAdapter:
     """Resolve a `SchemaSpec` to a `BIDSSchemaAdapter`.
 
     Hashable specs (`None`, `str`, `PathT`) hit a memoized loader.

--- a/bids2table/_schema.py
+++ b/bids2table/_schema.py
@@ -7,10 +7,15 @@ full design.
 """
 
 import json
+import os
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any
 
+import bidsschematools.schema
 from bidsschematools.types import Namespace
+
+from bids2table._pathlib import PathT
 
 
 def encode_metadata(metadata: dict[str, Any]) -> dict[bytes, bytes]:
@@ -102,4 +107,28 @@ def _build_adapter_from_namespace(schema: Namespace) -> BIDSSchemaAdapter:
         bids_version=schema["bids_version"],
         schema_version=schema["schema_version"],
         entity_schema=entity_schema,
+    )
+
+
+@lru_cache
+def _load_from_path(path: str | PathT | None) -> BIDSSchemaAdapter:
+    """Load and cache a BIDSSchemaAdapter from a path or the default schema."""
+    schema = bidsschematools.schema.load_schema(path)
+    return _build_adapter_from_namespace(schema)
+
+
+def load_bids_schema(spec=None) -> BIDSSchemaAdapter:
+    """Resolve a `SchemaSpec` to a `BIDSSchemaAdapter`.
+
+    Hashable specs (`None`, `str`, `PathT`) hit a memoized loader.
+    `Namespace` instances fall through to a fresh build per call;
+    `Namespace` is not stably hashable and the caller has already paid
+    the load cost.
+    """
+    if isinstance(spec, Namespace):
+        return _build_adapter_from_namespace(spec)
+    if spec is None or isinstance(spec, (str, os.PathLike)):
+        return _load_from_path(spec)
+    raise TypeError(
+        f"schema must be Namespace | str | PathT | None, got {type(spec).__name__}"
     )

--- a/bids2table/_schema.py
+++ b/bids2table/_schema.py
@@ -7,6 +7,7 @@ full design.
 """
 
 import json
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -43,3 +44,21 @@ def decode_metadata(metadata: dict[bytes, bytes]) -> dict[str, Any]:
         except json.JSONDecodeError:
             out[k.decode()] = s
     return out
+
+
+@dataclass(frozen=True)
+class BIDSSchemaAdapter:
+    """Internal value object holding the BIDS schema components bids2table uses.
+
+    `entity_schema` is excluded from `__hash__` (its dict value is unhashable)
+    but included in `__eq__`. This means two adapters with the same
+    (bids_version, schema_version) hash identically; structural equality
+    falls through to compare `entity_schema`. `lru_cache` therefore treats
+    same-version-different-content adapters as distinct entries.
+
+    Not part of the public API.
+    """
+
+    bids_version: str
+    schema_version: str
+    entity_schema: dict[str, dict[str, Any]] = field(hash=False)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,7 +1,9 @@
 import logging
+from copy import deepcopy
 from itertools import islice
 from pathlib import Path
 
+import bidsschematools.schema
 import pyarrow as pa
 import pytest
 from pytest import LogCaptureFixture
@@ -244,3 +246,34 @@ def test_filter_include_exclude():
 )
 def test_h_fmt(num: int, expected: str):
     assert indexing._hfmt(num) == expected
+
+
+def test_index_dataset_accepts_schema_kwarg(tmp_path):
+    # Build a minimal BIDS dataset.
+    sub = tmp_path / "ds" / "sub-A01" / "anat"
+    sub.mkdir(parents=True)
+    (tmp_path / "ds" / "dataset_description.json").write_text('{"Name": "ds"}')
+    (sub / "sub-A01_T1w.nii.gz").touch()
+
+    ns = deepcopy(bidsschematools.schema.load_schema())
+    ns.objects.entities.subject["description"] = "Modified once"
+    table = indexing.index_dataset(tmp_path / "ds", schema=ns)
+    assert table.num_rows == 1
+    assert "sub" in table.column_names
+    assert table.schema.field("sub").metadata[b"description"] == b"Modified once"
+
+
+def test_batch_index_dataset_accepts_schema_kwarg(tmp_path):
+    from bids2table._indexing import batch_index_dataset
+
+    ds1 = tmp_path / "a"
+    (ds1 / "sub-A01" / "anat").mkdir(parents=True)
+    (ds1 / "dataset_description.json").write_text('{"Name": "a"}')
+    (ds1 / "sub-A01" / "anat" / "sub-A01_T1w.nii.gz").touch()
+
+    ns = deepcopy(bidsschematools.schema.load_schema())
+    ns.objects.entities.subject["description"] = "And again"
+    tables = list(batch_index_dataset([ds1], schema=ns))
+    assert len(tables) == 1
+    assert tables[0].num_rows == 1
+    assert tables[0].schema.field("sub").metadata[b"description"] == b"And again"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -214,3 +214,22 @@ def test_pyarrow_validate_entities_takes_only_pa_schema():
     valid, extra = _pyarrow_validate_entities({"sub": "A01"}, pa_schema=pa_schema)
     assert valid["sub"] == "A01"
     assert extra == {}
+
+
+def test_get_arrow_schema_accepts_schema_kwarg():
+    from bids2table._indexing import get_arrow_schema
+
+    ns = bidsschematools.schema.load_schema()
+    schema = get_arrow_schema(schema=ns)
+    assert isinstance(schema, pa.Schema)
+    assert "sub" in schema.names
+    assert "dataset" in schema.names
+    assert "extra_entities" in schema.names
+
+
+def test_get_column_names_accepts_schema_kwarg():
+    from bids2table._indexing import get_column_names
+
+    ns = bidsschematools.schema.load_schema()
+    cols = get_column_names(schema=ns)
+    assert any(c.value == "sub" for c in cols)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,32 @@
+import pytest
+
+from bids2table._schema import decode_metadata, encode_metadata
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"name": "sub"},
+        {"name": "sub", "format": "label"},
+        {"name": "task", "format": "label", "enum": ["rest", "task"]},
+        {"name": "run", "format": "index"},
+        {"description": "Hello world"},
+        {"display_name": "Subject", "format": "label", "enum": ["A", "B", "C"]},
+    ],
+)
+def test_metadata_roundtrip(metadata):
+    encoded = encode_metadata(metadata)
+    assert all(isinstance(k, bytes) for k in encoded)
+    assert all(isinstance(v, bytes) for v in encoded.values())
+    decoded = decode_metadata(encoded)
+    assert decoded == metadata
+
+
+def test_encode_keeps_strings_verbatim():
+    encoded = encode_metadata({"name": "sub"})
+    assert encoded == {b"name": b"sub"}
+
+
+def test_encode_json_encodes_non_strings():
+    encoded = encode_metadata({"enum": ["a", "b"]})
+    assert encoded == {b"enum": b'["a", "b"]'}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,9 @@
+import functools
+from dataclasses import FrozenInstanceError
+
 import pytest
 
-from bids2table._schema import decode_metadata, encode_metadata
+from bids2table._schema import BIDSSchemaAdapter, decode_metadata, encode_metadata
 
 
 @pytest.mark.parametrize(
@@ -30,3 +33,54 @@ def test_encode_keeps_strings_verbatim():
 def test_encode_json_encodes_non_strings():
     encoded = encode_metadata({"enum": ["a", "b"]})
     assert encoded == {b"enum": b'["a", "b"]'}
+
+
+def _adapter(versions=("1.0.0", "0.1.0"), entities=None):
+    return BIDSSchemaAdapter(
+        bids_version=versions[0],
+        schema_version=versions[1],
+        entity_schema=entities or {"sub": {"name": "sub", "format": "label"}},
+    )
+
+
+def test_adapter_equal_when_all_fields_equal():
+    a = _adapter()
+    b = _adapter()
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+def test_adapter_unequal_when_entity_schema_differs():
+    a = _adapter(entities={"sub": {"name": "sub"}})
+    b = _adapter(entities={"task": {"name": "task"}})
+    assert a != b
+    # Same versions → same hash bucket; eq fall-through distinguishes them.
+    assert hash(a) == hash(b)
+
+
+def test_adapter_unequal_and_different_hash_when_versions_differ():
+    a = _adapter(versions=("1.0.0", "0.1.0"))
+    b = _adapter(versions=("2.0.0", "0.1.0"))
+    assert a != b
+    assert hash(a) != hash(b)
+
+
+def test_adapter_lru_cache_distinguishes_same_version_different_content():
+    """A function memoized on the adapter must not collide across distinct
+    adapters that happen to share versions."""
+
+    @functools.lru_cache
+    def derive(adapter: BIDSSchemaAdapter) -> int:
+        return id(adapter.entity_schema)
+
+    a = _adapter(entities={"sub": {"name": "sub"}})
+    b = _adapter(entities={"task": {"name": "task"}})
+    assert derive(a) != derive(b)
+    # And cache hit on identical adapter:
+    assert derive(a) == derive(_adapter(entities={"sub": {"name": "sub"}}))
+
+
+def test_adapter_is_frozen():
+    a = _adapter()
+    with pytest.raises(FrozenInstanceError):
+        a.bids_version = "9.9.9"  # type: ignore[misc]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -186,3 +186,31 @@ def test_lookups_from_arrow_skips_non_entity_fields():
     full = pa.schema(list(entity_schema) + [extra], metadata=entity_schema.metadata)
     name_map, _ = _lookups_from_arrow(full)
     assert "dataset" not in name_map
+
+
+def test_validate_bids_entities_accepts_schema_kwarg_namespace():
+    from bids2table._entities import validate_bids_entities
+
+    ns = bidsschematools.schema.load_schema()
+    valid, extra = validate_bids_entities({"sub": "A01", "task": "rest"}, schema=ns)
+    assert valid["sub"] == "A01"
+    assert valid["task"] == "rest"
+    assert extra == {}
+
+
+def test_validate_bids_entities_default_schema():
+    from bids2table._entities import validate_bids_entities
+
+    valid, extra = validate_bids_entities({"sub": "A01", "unknown": "x"})
+    assert valid["sub"] == "A01"
+    assert extra == {"unknown": "x"}
+
+
+def test_pyarrow_validate_entities_takes_only_pa_schema():
+    from bids2table._entities import _pyarrow_validate_entities
+
+    adapter = load_bids_schema()
+    pa_schema = entity_arrow_schema(adapter)
+    valid, extra = _pyarrow_validate_entities({"sub": "A01"}, pa_schema=pa_schema)
+    assert valid["sub"] == "A01"
+    assert extra == {}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,9 +1,15 @@
 import functools
 from dataclasses import FrozenInstanceError
 
+import bidsschematools.schema
 import pytest
 
-from bids2table._schema import BIDSSchemaAdapter, decode_metadata, encode_metadata
+from bids2table._schema import (
+    BIDSSchemaAdapter,
+    _build_adapter_from_namespace,
+    decode_metadata,
+    encode_metadata,
+)
 
 
 @pytest.mark.parametrize(
@@ -84,3 +90,19 @@ def test_adapter_is_frozen():
     a = _adapter()
     with pytest.raises(FrozenInstanceError):
         a.bids_version = "9.9.9"  # type: ignore[misc]
+
+
+def test_build_adapter_from_namespace_uses_versions_and_entities():
+    ns = bidsschematools.schema.load_schema()
+    adapter = _build_adapter_from_namespace(ns)
+
+    assert adapter.bids_version == ns["bids_version"]
+    assert adapter.schema_version == ns["schema_version"]
+
+    # All entities listed in rules.entities are present.
+    for entity in ns.rules.entities:
+        assert entity in adapter.entity_schema
+
+    # Special entities are added.
+    for special in ("datatype", "suffix", "extension"):
+        assert special in adapter.entity_schema

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,6 +2,7 @@ import functools
 from dataclasses import FrozenInstanceError
 
 import bidsschematools.schema
+import pyarrow as pa
 import pytest
 
 from bids2table._schema import (
@@ -9,6 +10,8 @@ from bids2table._schema import (
     _build_adapter_from_namespace,
     decode_metadata,
     encode_metadata,
+    entity_arrow_schema,
+    load_bids_schema,
 )
 
 
@@ -100,25 +103,19 @@ def test_build_adapter_from_namespace_uses_versions_and_entities():
     assert adapter.schema_version == ns["schema_version"]
 
     # All entities listed in rules.entities are present.
-    for entity in ns.rules.entities:
-        assert entity in adapter.entity_schema
+    assert set(ns.rules.entities) <= adapter.entity_schema.keys()
 
     # Special entities are added.
-    for special in ("datatype", "suffix", "extension"):
-        assert special in adapter.entity_schema
+    assert {"datatype", "suffix", "extension"} <= adapter.entity_schema.keys()
 
 
 def test_load_bids_schema_default_is_cached():
-    from bids2table._schema import load_bids_schema
-
     a = load_bids_schema()
     b = load_bids_schema(None)
     assert a is b
 
 
 def test_load_bids_schema_namespace_path_returns_equal_but_fresh():
-    from bids2table._schema import load_bids_schema
-
     ns = bidsschematools.schema.load_schema()
     a = load_bids_schema(ns)
     b = load_bids_schema(ns)
@@ -128,7 +125,27 @@ def test_load_bids_schema_namespace_path_returns_equal_but_fresh():
 
 
 def test_load_bids_schema_rejects_unsupported_type():
-    from bids2table._schema import load_bids_schema
-
     with pytest.raises(TypeError):
         load_bids_schema(42)  # type: ignore[arg-type]
+
+
+def test_entity_arrow_schema_metadata_is_bytes():
+    adapter = load_bids_schema()
+    schema = entity_arrow_schema(adapter)
+    assert isinstance(schema, pa.Schema)
+    assert schema.metadata[b"bids_version"].decode() == adapter.bids_version
+    assert schema.metadata[b"schema_version"].decode() == adapter.schema_version
+
+
+def test_entity_arrow_schema_field_carries_entity_metadata():
+    adapter = load_bids_schema()
+    schema = entity_arrow_schema(adapter)
+    sub_field = schema.field("sub")
+    assert sub_field.metadata[b"entity"] == b"subject"
+
+
+def test_entity_arrow_schema_is_cached():
+    adapter = load_bids_schema()
+    a = entity_arrow_schema(adapter)
+    b = entity_arrow_schema(adapter)
+    assert a is b

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -149,3 +149,40 @@ def test_entity_arrow_schema_is_cached():
     a = entity_arrow_schema(adapter)
     b = entity_arrow_schema(adapter)
     assert a is b
+
+
+def test_lookups_from_arrow_round_trips_with_adapter():
+    from bids2table._entities import _lookups_from_arrow
+
+    adapter = load_bids_schema()
+    schema = entity_arrow_schema(adapter)
+    name_entity_map, entity_cfg = _lookups_from_arrow(schema)
+
+    # Recovers entity schema content from the Arrow schema metadata.
+    assert entity_cfg == adapter.entity_schema
+    # The name-entity map is precomputed and included in memoized results.
+    assert name_entity_map == {
+        cfg["name"]: entity for entity, cfg in adapter.entity_schema.items()
+    }
+
+
+def test_lookups_from_arrow_is_cached():
+    from bids2table._entities import _lookups_from_arrow
+
+    adapter = load_bids_schema()
+    schema = entity_arrow_schema(adapter)
+    a = _lookups_from_arrow(schema)
+    b = _lookups_from_arrow(schema)
+    assert a is b
+
+
+def test_lookups_from_arrow_skips_non_entity_fields():
+    """Non-entity fields (no 'entity' key in metadata) must be skipped."""
+    from bids2table._entities import _lookups_from_arrow
+
+    adapter = load_bids_schema()
+    entity_schema = entity_arrow_schema(adapter)
+    extra = pa.field("dataset", pa.string(), metadata={b"name": b"dataset"})
+    full = pa.schema(list(entity_schema) + [extra], metadata=entity_schema.metadata)
+    name_map, _ = _lookups_from_arrow(full)
+    assert "dataset" not in name_map

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -106,3 +106,29 @@ def test_build_adapter_from_namespace_uses_versions_and_entities():
     # Special entities are added.
     for special in ("datatype", "suffix", "extension"):
         assert special in adapter.entity_schema
+
+
+def test_load_bids_schema_default_is_cached():
+    from bids2table._schema import load_bids_schema
+
+    a = load_bids_schema()
+    b = load_bids_schema(None)
+    assert a is b
+
+
+def test_load_bids_schema_namespace_path_returns_equal_but_fresh():
+    from bids2table._schema import load_bids_schema
+
+    ns = bidsschematools.schema.load_schema()
+    a = load_bids_schema(ns)
+    b = load_bids_schema(ns)
+    # Equal by value, distinct by identity (no Namespace caching).
+    assert a == b
+    assert a is not b
+
+
+def test_load_bids_schema_rejects_unsupported_type():
+    from bids2table._schema import load_bids_schema
+
+    with pytest.raises(TypeError):
+        load_bids_schema(42)  # type: ignore[arg-type]


### PR DESCRIPTION
This is a backwards-incompatible break of the current API.

Along the lines of https://github.com/childmindresearch/bids2table/issues/70#issuecomment-4363904572, this introduces a public type:

```py
SchemaSpec: TypeAlias = Namespace | str | PathT | None
```

This allows a schema reference or schema object to be passed to any of:

- `validate_bids_entities`
- `get_arrow_schema`
- `get_column_names`
- `index_dataset`
- `batch_index_dataset`

These functions turn the schema spec into a `BIDSSchemaAdapter` object, which encapsulates the components that are used by bids2table, and should be extensible going forward:

```py
@dataclass(frozen=True)
class BIDSSchemaAdapter:
    bids_version: str
    schema_version: str
    entity_schema: dict[str, dict[str, Any]] = field(hash=False)
```

The only current direct consumer is:

```py
def entity_arrow_schema(adapter: BIDSSchemaAdapter) -> pa.Schema: ...
```

The only current consumer of `pa.Schema` is:

```py
def _pyarrow_validate_entities(entities: dict[str, Any], *, pa_schema: pa.Schema) -> tuple[dict[str, BIDSValue], dict[str, Any]]: ...
```

Which is called by the dataset indexer and the public API function `validate_bids_entities`. The main reason for this indirection is that `pa.Schema` is passed to `_index_dataset_subject_dir` and I didn't want to refactor that more than necessary, but this seems like a good, future-thinking approach anyway: By pulling the validation metadata out of the pyarrow schema, a parquet file contains what is needed to validate itself, without needing to look up and load the original schema.

That said, that isn't done here, and I could refactor these functions to take a `BIDSSchemaAdapter`, which will save a round-trip of metadata into and out of `pyarrow.Schema`.

Closes #70.
Replaces #71.