### PR TITLE
Fix coverage commenting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ on:
 
 env:
   UV_FROZEN: true
+  COVERAGE_PYTHON: "3.12"
 
 jobs:
   format:
@@ -66,10 +67,16 @@ jobs:
             pytest-cloud.xml \
             pytest.xml
 
+      - name: Record PR number
+        if: github.event_name == 'pull_request' && matrix.python-version == env.COVERAGE_PYTHON
+        run: echo "${{ github.event.number }}" > pr-number.txt
+
       - uses: actions/upload-artifact@v7
-        if: github.event_name == 'pull_request' && matrix.python-version == '3.12'
+        if: github.event_name == 'pull_request' && matrix.python-version == env.COVERAGE_PYTHON
         with:
-          name: coverage-${{ github.event.number }}
+          name: coverage
+          retention-days: 1
           path: |
             coverage.xml
             pytest.xml
+            pr-number.txt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,17 +2,15 @@ name: CI
 
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   UV_FROZEN: true
-  COVERAGE_PYTHON: "3.12"
 
 jobs:
   format:
@@ -33,7 +31,7 @@ jobs:
     needs: format
     strategy:
       matrix:
-        python-version: [ "3.11", "3.12", "3.13", "3.14" ]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -68,10 +66,10 @@ jobs:
             pytest-cloud.xml \
             pytest.xml
 
-      - name: Pytest coverage comment
-        if: github.event_name == 'pull_request' && matrix.python-version ==
-          env.COVERAGE_PYTHON
-        uses: MishaKav/pytest-coverage-comment@v1
+      - uses: actions/upload-artifact@v7
+        if: github.event_name == 'pull_request' && matrix.python-version == '3.12'
         with:
-          pytest-xml-coverage-path: ./coverage.xml
-          junitxml-path: ./pytest.xml
+          name: coverage-${{ github.event.number }}
+          path: |
+            coverage.xml
+            pytest.xml

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,22 @@
+name: Coverage report
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: coverage-${{ github.event.workflow_run.pull_requests[0].number }}
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@v1
+        with:
+          pytest-xml-coverage-path: ./coverage.xml
+          junitxml-path: ./pytest.xml

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -7,16 +7,27 @@ on:
 
 permissions:
   pull-requests: write
+  actions: read
 
 jobs:
   coverage:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: coverage-${{ github.event.workflow_run.pull_requests[0].number }}
+          name: coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
       - name: Pytest coverage comment
         uses: MishaKav/pytest-coverage-comment@v1
         with:
+          issue-number: ${{ steps.pr.outputs.number }}
           pytest-xml-coverage-path: ./coverage.xml
           junitxml-path: ./pytest.xml


### PR DESCRIPTION
Splits the commenting from the CI by:
  1. Performing the testing and uploading the coverage files in `ci.yaml` workflow
  2. Downloading coverage and commenting, never checking out the code (`coverage.yaml`) workflow.

This should allow for non-organization contributors to make PRs while still facilitating the coverage commenting without requiring the change of trigger from "pull_request" to "pull_request_target", which may introduce security vulnerabilities targeting the tests.

@nx10, mind taking a quick look at this one. The only part I am not certain about is the downloading of the artifact and if it ends up grabbing the correct PR number (i.e. artifact name) in the the subsequent workflow. Primarily needed some way of ensuring each artifact was unique to the PR.