### PR TITLE
Serialize subject-level indexer

### DIFF
--- a/bids2table/__main__.py
+++ b/bids2table/__main__.py
@@ -122,6 +122,15 @@ def _index_command(args: argparse.Namespace):
         )
         pq.write_table(table, args.output)
     else:
+        # Logic to hand in piped in datasets / no datasets
+        if len(root) == 0 and not sys.stdin.isatty():
+            # read datasets from stdin, one per line
+            root = (line.strip() for line in sys.stdin if line.strip())
+        elif len(root) == 0:
+            _logger.error("No datasets to index given; exiting.")
+            sys.exit(1)
+
+        # Set up for parallelism
         max_workers = None if args.workers == -1 else args.workers
         if args.use_threads:
             executor_cls = concurrent.futures.ThreadPoolExecutor

--- a/bids2table/__main__.py
+++ b/bids2table/__main__.py
@@ -37,14 +37,14 @@ def main():
         "--workers",
         "-j",
         type=int,
-        help="Number of worker processes. Setting to -1 runs as many workers as there "
+        help="Number of worker processes for dataset-level parallelism. Setting to -1 runs as many workers as there "
         "are cores available. Setting to 0 runs in the main process. (default: 0)",
         default=0,
     )
     parser_index.add_argument(
         "--use-threads",
         action="store_true",
-        help="Use threads instead of processes when workers > 0.",
+        help="Use threads instead of processes when workers > 0 (dataset-level parallelism only).",
     )
     parser_index.add_argument(
         "--no-progress", "-q", action="store_true", help="Disable the progress bar."
@@ -105,12 +105,6 @@ def _index_command(args: argparse.Namespace):
     for path in args.root:
         _check_path(path)
 
-    max_workers = None if args.workers == -1 else args.workers
-    if args.use_threads:
-        executor_cls = concurrent.futures.ThreadPoolExecutor
-    else:
-        executor_cls = concurrent.futures.ProcessPoolExecutor
-
     root = []
     for path in args.root:
         if glob.has_magic(path):
@@ -124,18 +118,15 @@ def _index_command(args: argparse.Namespace):
         table = b2t2.index_dataset(
             root[0],
             include_subjects=args.subjects,
-            max_workers=max_workers,
-            executor_cls=executor_cls,
             show_progress=not args.no_progress,
         )
         pq.write_table(table, args.output)
     else:
-        if len(root) == 0 and not sys.stdin.isatty():
-            # read datasets from stdin, one per line
-            root = (line.strip() for line in sys.stdin if line.strip())
-        elif len(root) == 0:
-            _logger.error("No datasets to index given; exiting.")
-            sys.exit(1)
+        max_workers = None if args.workers == -1 else args.workers
+        if args.use_threads:
+            executor_cls = concurrent.futures.ThreadPoolExecutor
+        else:
+            executor_cls = concurrent.futures.ProcessPoolExecutor
 
         schema = b2t2.get_arrow_schema()
         with pq.ParquetWriter(args.output, schema=schema) as writer:

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -196,9 +196,6 @@ def find_bids_datasets(
 def index_dataset(
     root: str | PathT,
     include_subjects: str | list[str] | None = None,
-    max_workers: int | None = 0,
-    chunksize: int = 32,
-    executor_cls: type[Executor] = ProcessPoolExecutor,
     show_progress: bool = False,
 ) -> pa.Table:
     """Index a BIDS dataset.
@@ -207,13 +204,6 @@ def index_dataset(
         root: BIDS dataset root directory.
         include_subjects: Glob pattern or list of patterns for matching subjects to
             include in the index.
-        max_workers: Number of indexing processes to run in parallel. Setting
-            `max_workers=0` (the default) uses the main process only. Setting
-            `max_workers=None` starts as many workers as there are available CPUs. See
-            `concurrent.futures.ProcessPoolExecutor` for details.
-        chunksize: Number of subjects per process task. Only used for
-            `ProcessPoolExecutor` when `max_workers > 0`.
-        executor_cls: Executor class to use for parallel indexing.
         show_progress: Show progress bar.
 
     Returns:
@@ -234,25 +224,12 @@ def index_dataset(
         _logger.warning(f"Path {root} contains no matching subject dirs.")
         return pa.Table.from_pylist([], schema=schema)
 
-    func = partial(_index_bids_subject_dir, schema=schema, dataset=dataset)
-
     tables = []
     file_count = 0
-    for sub, table in (
-        pbar := tqdm(
-            _pmap(func, subject_dirs, max_workers, chunksize, executor_cls),
-            desc=dataset,
-            total=len(subject_dirs),
-            disable=not show_progress,
-        )
-    ):
-        file_count += len(table)
-        pbar.set_postfix(dict(sub=sub, N=_hfmt(file_count)), refresh=False)
+    for sub in subject_dirs:
+        _, table = _index_bids_subject_dir(sub, schema=schema, dataset=dataset)
         tables.append(table)
-
-    # NOTE: concat_tables produces a table where each column is a ChunkedArray, with one
-    # chunk per original subject table. Is it better to keep the original chunks (one
-    # per subject) or merge using `combine_chunks`?
+        file_count += len(table)
     table = pa.concat_tables(tables).combine_chunks()
     return table
 
@@ -292,7 +269,7 @@ def batch_index_dataset(
 
 def _batch_index_func(root: str | PathT) -> tuple[str | None, pa.Table]:
     dataset, _ = _get_bids_dataset(root)
-    table = index_dataset(root, max_workers=0, show_progress=False)
+    table = index_dataset(root, show_progress=False)
     return dataset, table
 
 

--- a/bids2table/_pathlib.py
+++ b/bids2table/_pathlib.py
@@ -16,7 +16,7 @@ try:
     except Exception:
         pass
 
-except ImportError:
+except Exception:
     AnyPath = CloudPath = Path
 
     _CLOUDPATHLIB_AVAILABLE = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "bids2table"
 dynamic = ["version"]
-authors = [{ name = "Connor Lane", email = "connor.lane858@gmail.com" }]
+authors = [
+  { name = "Connor Lane", email = "connor.lane858@gmail.com" },
+  { name = "Jason Kai" },
+  { name = "Florian Rupprecht" },
+  { name = "Gregory Kiar" }
+]
 description = "Index BIDS datasets fast, locally or in the cloud."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/benchmarks/test_index.py
+++ b/tests/benchmarks/test_index.py
@@ -34,7 +34,7 @@ def _run_benchmark(
     func: Callable,
     index_fpath: Path,
     version: str,
-    workers: int,
+    workers: int = 1,
     *args,
     **kwargs,
 ) -> None:
@@ -58,11 +58,7 @@ def _run_benchmark(
 
     # Additional info
     benchmark.extra_info.update(
-        {
-            "size_mb": sizes,
-            "version": version or "Unknown",
-            "workers": workers or "Unknown",
-        }
+        {"size_mb": sizes, "version": version or "Unknown", "workers": workers or 1}
     )
 
 
@@ -90,20 +86,19 @@ def test_openneuro(benchmark: BenchmarkFixture, tmp_path: Path) -> None:
         benchmark,
         index,
         index_fpath=index_fpath,
-        version=b2t2.__version__,
         workers=workers,
+        version=b2t2.__version__,
     )
 
 
 @pytest.mark.benchmark
-@pytest.mark.parametrize("workers", (1, 4))
-def test_local(benchmark: BenchmarkFixture, tmp_path: Path, workers: int) -> None:
+def test_local(benchmark: BenchmarkFixture, tmp_path: Path) -> None:
     """Bids2Table v2 benchmarking on local dataset."""
     index_fpath = tmp_path / "index.parquet"
     data_dir = Path("bids-examples/ds000117")
 
     def index() -> None:
-        table = b2t2.index_dataset(data_dir, max_workers=workers, show_progress=False)
+        table = b2t2.index_dataset(data_dir, show_progress=False)
         pq.write_table(table, index_fpath)
 
     _run_benchmark(
@@ -111,5 +106,4 @@ def test_local(benchmark: BenchmarkFixture, tmp_path: Path, workers: int) -> Non
         index,
         index_fpath=index_fpath,
         version=b2t2.__version__,
-        workers=workers,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def pytest_configure(config):
 
 def pytest_runtest_setup(item):
     if "cloud" in item.keywords and not cloudpathlib_is_available():
-            pytest.skip("cloudpathlib is not available or not fully functional")
+        pytest.skip("cloudpathlib is not available or not fully functional")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,7 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    if "cloud" in item.keywords:
-        if not cloudpathlib_is_available():
+    if "cloud" in item.keywords and not cloudpathlib_is_available():
             pytest.skip("cloudpathlib is not available or not fully functional")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,6 @@ import pytest
 from bids2table._pathlib import cloudpathlib_is_available
 
 
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "cloud: Tests requiring cloud group dependencies"
-    )
-
-
 def pytest_runtest_setup(item):
     if "cloud" in item.keywords and not cloudpathlib_is_available():
         pytest.skip("cloudpathlib is not available or not fully functional")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,20 @@ from pathlib import Path
 
 import pytest
 
+from bids2table._pathlib import cloudpathlib_is_available
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "cloud: Tests requiring cloud group dependencies"
+    )
+
+
+def pytest_runtest_setup(item):
+    if "cloud" in item.keywords:
+        if not cloudpathlib_is_available():
+            pytest.skip("cloudpathlib is not available or not fully functional")
+
 
 @pytest.fixture
 def symlink_dataset(tmp_path: Path, sub: str = "sub-001", ses: str = "ses-001") -> Path:

--- a/tests/pybids/test_bidsfile.py
+++ b/tests/pybids/test_bidsfile.py
@@ -1,6 +1,10 @@
 """Tests for BIDSFile class."""
 
-from bids2table.pybids import BIDSFile
+import pytest
+
+pandas = pytest.importorskip("pandas", reason="pandas not available")
+
+from bids2table.pybids import BIDSFile  # noqa: E402 - skip tests if pandas not avail
 
 
 def test_bidsfile_init():

--- a/tests/pybids/test_custom_entities.py
+++ b/tests/pybids/test_custom_entities.py
@@ -5,7 +5,9 @@ from pathlib import Path
 
 import pytest
 
-from bids2table.pybids import BIDSLayout
+pandas = pytest.importorskip("pandas", reason="pandas not available")
+
+from bids2table.pybids import BIDSLayout  # noqa: E402 - skip tests if pandas not avail
 
 
 @pytest.fixture

--- a/tests/pybids/test_layout.py
+++ b/tests/pybids/test_layout.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from bids2table.pybids import BIDSFile, BIDSLayout, Query
+pytest.importorskip("pandas", reason="pandas not available")
+
+from bids2table.pybids import (  # noqa: E402 - skip tests if pandas not avail
+    BIDSFile,
+    BIDSLayout,
+    Query,
+)
 
 
 # Fixture for test dataset

--- a/tests/pybids/test_layout.py
+++ b/tests/pybids/test_layout.py
@@ -13,7 +13,7 @@ from bids2table.pybids import BIDSFile, BIDSLayout, Query
 def test_dataset():
     """Return path to a test BIDS dataset."""
     # Use one of the bids-examples datasets
-    dataset_path = Path(__file__).parents[2] / "bids-examples" / "ds001"
+    dataset_path = Path(__file__).parents[2] / "bids-examples" / "ds114"
     if not dataset_path.exists():
         pytest.skip(f"Test dataset not found: {dataset_path}")
     return dataset_path

--- a/tests/pybids/test_query.py
+++ b/tests/pybids/test_query.py
@@ -1,6 +1,10 @@
 """Tests for Query class."""
 
-from bids2table.pybids import Query
+import pytest
+
+pytest.importorskip("pandas", reason="pandas not available")
+
+from bids2table.pybids import Query  # noqa: E402 - skip tests if pandas not avail
 
 
 def test_query_sentinels_are_unique():


### PR DESCRIPTION
## Summary

Refactored the indexer to shift parallelism from subject-level to dataset-level, simplifying the architecture for future generalization.

## Changes
- bids2table/_indexing.py:
  - Removed max_workers, chunksize, executor_cls from index_dataset signature
  - Replaced _pmap with sequential for loop in index_dataset body
  - Updated docstring to reflect sequential subject indexing
- bids2table/_pathlib.py:
  - Generalized exception handling to catch all exceptions (not just ImportError) when importing/configuring cloudpathlib
  - Falls back to pathlib.Path when cloudpathlib clients fail to initialize
- bids2table/\_\_main__.py:
  - Removed parallelism arguments from index_dataset call in CLI
  - Kept batch_index_dataset parallelism unchanged (dataset-level only)
- tests/conftest.py:
  - Added pytest hook to skip cloud tests when cloudpathlib isn't available or functional
- tests/pybids/test_layout.py:
  - Picked a better dataset, since previous choice didn't test session-level functionality.
- pyproject.toml:
  - Updated author list to be more modern and accurate.

## Rationale
- Subject-level parallelism provided minimal efficiency gains while constraining future architectural generalization (such as supporting indexing of bids datasets that do not start with subject-level directories)
- Dataset-level parallelism via batch_index_dataset remains intact
- Cloudpathlib exception handling now gracefully handles runtime configuration failures (not just import failures)