### PR TITLE
Fix benchmark CI for forks

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -17,7 +17,11 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-          ref: ${{ github.head_ref }}
+      # Necessary for forks
+      - name: Create local branch
+        run: |
+          git checkout -b "$BRANCH_NAME" || git checkout "$BRANCH_NAME" && \
+          git checkout main
       - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync --frozen --all-extras
       - name: Run benchmarks

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,11 +1,14 @@
 # /// script
 # requires-python = ">=3.13"
-# dependencies = []
+# dependencies = [
+#     "pytest>=9.1.1",
+#     "pytest-benchmark>=5.2.3",
+# ]
 # ///
 """Perform benchmarking of bids2table against last tag, main and feature branches.
 
 Run with:
-    uv run --with <repo> scripts/benchmark.py \
+    uv run scripts/benchmark.py \
         -b <feature_branch> [-o <output_dir>] [-f <output_file>] [-t <threshold>]
 """
 
@@ -311,7 +314,7 @@ def run_benchmark(git: Git, branch: str, out_dir: Path) -> None:
                     "--benchmark-time-unit=ms",
                     "--benchmark-warmup=on",
                     f"{git.repo_path}/tests",
-                ]
+                ],
             )
 
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -269,6 +269,12 @@ def _parser() -> argparse.Namespace:
         type=float,
         help="Threshold for performance to be considered unchanged",
     )
+    parser.add_argument(
+        "-k",
+        "--filter",
+        default=None,
+        help="pytest -k expression to filter which benchmarks to run",
+    )
     return parser.parse_args()
 
 
@@ -276,7 +282,9 @@ def _sanitize(s: str) -> str:
     return s.replace("/", "-")
 
 
-def run_benchmark(git: Git, branch: str, out_dir: Path) -> None:
+def run_benchmark(
+    git: Git, branch: str, out_dir: Path, filter_expr: str | None = None
+) -> None:
     """Perform benchmarking.
 
     Args:
@@ -305,17 +313,18 @@ def run_benchmark(git: Git, branch: str, out_dir: Path) -> None:
                 )
 
             # Run benchmark
-            pytest.main(
-                [
-                    "-m",
-                    "benchmark",
-                    "--benchmark-save-data",
-                    f"--benchmark-json={fname}",
-                    "--benchmark-time-unit=ms",
-                    "--benchmark-warmup=on",
-                    f"{git.repo_path}/tests",
-                ],
-            )
+            pytest_args = [
+                "-m",
+                "benchmark",
+                "--benchmark-save-data",
+                f"--benchmark-json={fname}",
+                "--benchmark-time-unit=ms",
+                "--benchmark-warmup=on",
+            ]
+            if filter_expr:
+                pytest_args.extend(["-k", filter_expr])
+            pytest_args.append(f"{git.repo_path}/tests")
+            pytest.main(pytest_args)
 
 
 def generate_report(
@@ -387,7 +396,12 @@ def main() -> None:
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     with Git() as git:
-        run_benchmark(git=git, branch=args.branch, out_dir=args.output_dir)
+        run_benchmark(
+            git=git,
+            branch=args.branch,
+            out_dir=args.output_dir,
+            filter_expr=args.filter,
+        )
         report_file = generate_report(
             git=git,
             branch=args.branch,

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _warm_schema():
+    """Preemptively load and internally cache schema for testing."""
+    from bidsschematools import schema
+
+    schema.load_schema()

--- a/tests/benchmarks/test_query.py
+++ b/tests/benchmarks/test_query.py
@@ -65,7 +65,7 @@ class TestB2TQuery:
         )
 
         def query() -> None:
-            table.select(["ext", "suffix", "fpath"]).filter(
+            table.filter(
                 (pl.col("ext") == ".nii.gz") & (pl.col("suffix") == "bold")
             ).get_column("fpath")
 
@@ -75,13 +75,11 @@ class TestB2TQuery:
         """Benchmark query via metadata."""
         table, version = index
         table = table.with_columns(
-            pl.col("json")
-            .map_elements(lambda x: x.get("EchoTime"), return_dtype=pl.Float64)
-            .alias("echo_time")
+            pl.col("json").struct.field("EchoTime").alias("echo_time")
         )
 
         def query() -> None:
-            table.select(["sub", "echo_time", "fpath"]).filter(
+            table.filter(
                 (pl.col("sub").is_in(SUBJECTS)) & (pl.col("echo_time") == TARGET_TE)
             ).get_column("fpath")
 

--- a/tests/benchmarks/test_query.py
+++ b/tests/benchmarks/test_query.py
@@ -31,7 +31,7 @@ def _run_benchmark(
 class TestB2TQuery:
     """Benchmark different b2t queries."""
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def index(self) -> tuple:
         """Index dataset with b2t."""
         data_dir = Path("bids-examples/ds000117")

--- a/tests/benchmarks/test_query.py
+++ b/tests/benchmarks/test_query.py
@@ -75,7 +75,9 @@ class TestB2TQuery:
         """Benchmark query via metadata."""
         table, version = index
         table = table.with_columns(
-            pl.col("json").struct.field("EchoTime").alias("echo_time")
+            pl.col("json")
+            .map_elements(lambda x: x.get("EchoTime"), return_dtype=pl.Float64)
+            .alias("echo_time")
         )
 
         def query() -> None:


### PR DESCRIPTION
Benchmark CI is unable to find the branch when triggered from a fork. This removes the `ref` from actions checkout, which should fix the issue. 

Also updates the `uv` script dependencies.