### PR TITLE
Stricter linting, formatting, and type-checking

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,22 +14,23 @@ env:
   COVERAGE_PYTHON: "3.12"
 
 jobs:
-  format:
+  quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: "true"
       - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync --all-extras
-      - name: Check quality
-        run: |
-          uv run ruff check bids2table tests
-          uv run ruff format --check bids2table tests
+      - name: Ruff format
+        run: uv run ruff format --check bids2table tests
+
+      - name: Ruff check
+        run: uv run ruff check bids2table tests
+      
+      - name: Ty check
+        run: uv run ty check
 
   tests:
     runs-on: ubuntu-latest
-    needs: format
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,63 @@
-exclude: 'build|third-party|.github'
+fail_fast: false
+exclude: build|third-party|.github
 
 default_language_version:
-    python: python3
+  python: python3
 
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: check-ast
-    -   id: check-merge-conflict
-    -   id: end-of-file-fixer
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  # Ruff version.
-  rev: v0.9.10
+  rev: v0.15.19
   hooks:
-    # Run the linter.
-    - id: ruff
-      args: [ --fix ]
-    # Run the formatter.
-    - id: ruff-format
+  - id: ruff-check
+  - id: ruff-format
+
+- repo: https://github.com/astral-sh/ty-pre-commit
+  rev: v0.0.53
+  hooks:
+  - id: ty
+
+- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+  rev: v2.16.0
+  hooks:
+  - id: pretty-format-yaml
+    args:
+    - --autofix
+    - --indent=2
+  - id: pretty-format-toml
+    exclude: ^uv.lock$
+    args:
+    - --autofix
+    - --indent=2
+    - --no-sort
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+  - id: check-case-conflict
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: pretty-format-json
+    args:
+    - --autofix
+    - --indent=4
+    - --no-sort-keys
+    exclude_types: [jupyter]
+  - id: check-merge-conflict
+  - id: check-yaml
+  - id: check-json
+  - id: check-toml
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.1
   hooks:
   - id: codespell
     additional_dependencies:
-      - tomli
+    - tomli
+
+- repo: local
+  hooks:
+  - id: yaml-file-extension
+    name: Prefer .yaml over .yml.
+    entry: YAML files must have .yaml extension.
+    language: fail
+    files: \.yml$

--- a/bids2table/__init__.py
+++ b/bids2table/__init__.py
@@ -34,4 +34,4 @@ from bids2table._indexing import (
 from bids2table._metadata import load_bids_metadata
 from bids2table._pathlib import cloudpathlib_is_available
 from bids2table._schema import SchemaSpec
-from bids2table._version import *
+from bids2table._version import *  # noqa: F403 - import all of generated module

--- a/bids2table/__init__.py
+++ b/bids2table/__init__.py
@@ -1,17 +1,17 @@
 """.. include:: ../README.md"""  # noqa: D415
 
 __all__ = [
-    "index_dataset",
+    "SchemaSpec",
     "batch_index_dataset",
+    "cloudpathlib_is_available",
     "find_bids_datasets",
+    "format_bids_path",
     "get_arrow_schema",
     "get_column_names",
+    "index_dataset",
+    "load_bids_metadata",
     "parse_bids_entities",
     "validate_bids_entities",
-    "format_bids_path",
-    "load_bids_metadata",
-    "cloudpathlib_is_available",
-    "SchemaSpec",
 ]
 
 import importlib.util

--- a/bids2table/__init__.py
+++ b/bids2table/__init__.py
@@ -19,19 +19,19 @@ import importlib.util
 if importlib.util.find_spec("pandas"):
     __all__.append("pybids")
 
-from ._entities import (
+from bids2table._entities import (
     format_bids_path,
     parse_bids_entities,
     validate_bids_entities,
 )
-from ._indexing import (
+from bids2table._indexing import (
     batch_index_dataset,
     find_bids_datasets,
     get_arrow_schema,
     get_column_names,
     index_dataset,
 )
-from ._metadata import load_bids_metadata
-from ._pathlib import cloudpathlib_is_available
-from ._schema import SchemaSpec
-from ._version import *
+from bids2table._metadata import load_bids_metadata
+from bids2table._pathlib import cloudpathlib_is_available
+from bids2table._schema import SchemaSpec
+from bids2table._version import *

--- a/bids2table/__main__.py
+++ b/bids2table/__main__.py
@@ -42,7 +42,7 @@ def main() -> None:
         type=int,
         help="Number of worker processes for dataset-level parallelism. Setting to -1 "
         "runs as many workers as there are cores available. Setting to 0 runs in the "
-        "main process. (default: %d)",
+        "main process. (default: %(default)d)",
         default=0,
     )
     parser_index.add_argument(

--- a/bids2table/__main__.py
+++ b/bids2table/__main__.py
@@ -1,3 +1,5 @@
+"""Main entry point of bids2table."""
+
 import argparse
 import concurrent.futures
 import glob
@@ -12,7 +14,8 @@ from bids2table._pathlib import as_path
 _logger = setup_logger(__package__)
 
 
-def main():
+def main() -> None:
+    """Main CLI entry point."""
     parser = argparse.ArgumentParser(description="Find and index BIDS datasets.")
     subparsers = parser.add_subparsers(dest="subcommand")
 
@@ -37,14 +40,16 @@ def main():
         "--workers",
         "-j",
         type=int,
-        help="Number of worker processes for dataset-level parallelism. Setting to -1 runs as many workers as there "
-        "are cores available. Setting to 0 runs in the main process. (default: 0)",
+        help="Number of worker processes for dataset-level parallelism. Setting to -1 "
+        "runs as many workers as there are cores available. Setting to 0 runs in the "
+        "main process. (default: %d)",
         default=0,
     )
     parser_index.add_argument(
         "--use-threads",
         action="store_true",
-        help="Use threads instead of processes when workers > 0 (dataset-level parallelism only).",
+        help="Use threads instead of processes when workers > 0 (dataset-level "
+        "parallelism only).",
     )
     parser_index.add_argument(
         "--no-progress", "-q", action="store_true", help="Disable the progress bar."
@@ -101,7 +106,7 @@ def main():
         parser.print_help()
 
 
-def _index_command(args: argparse.Namespace):
+def _index_command(args: argparse.Namespace) -> None:
     for path in args.root:
         _check_path(path)
 
@@ -148,7 +153,7 @@ def _index_command(args: argparse.Namespace):
                 writer.write_table(table)
 
 
-def _find_command(args: argparse.Namespace):
+def _find_command(args: argparse.Namespace) -> None:
     _check_path(args.root)
 
     for dataset in b2t2.find_bids_datasets(
@@ -156,10 +161,10 @@ def _find_command(args: argparse.Namespace):
         exclude=args.exclude_dirs,
         maxdepth=args.maxdepth,
     ):
-        print(dataset)
+        _logger.info(dataset)
 
 
-def _check_path(path: str):
+def _check_path(path: str) -> None:
     if path.startswith(("s3://", "gs://")) and not b2t2.cloudpathlib_is_available():
         _logger.error(
             "Cloudpathlib is required to use cloud paths. "

--- a/bids2table/__main__.py
+++ b/bids2table/__main__.py
@@ -120,11 +120,7 @@ def _index_command(args: argparse.Namespace) -> None:
             root.append(path)
 
     if len(root) == 1:
-        table = b2t2.index_dataset(
-            root[0],
-            include_subjects=args.subjects,
-            show_progress=not args.no_progress,
-        )
+        table = b2t2.index_dataset(root[0], include_subjects=args.subjects)
         pq.write_table(table, args.output)
     else:
         # Logic to hand in piped in datasets / no datasets
@@ -145,7 +141,7 @@ def _index_command(args: argparse.Namespace) -> None:
         schema = b2t2.get_arrow_schema()
         with pq.ParquetWriter(args.output, schema=schema) as writer:
             for table in b2t2.batch_index_dataset(
-                root,
+                list(root),
                 max_workers=max_workers,
                 executor_cls=executor_cls,
                 show_progress=not args.no_progress,

--- a/bids2table/_entities.py
+++ b/bids2table/_entities.py
@@ -10,8 +10,8 @@ from typing import Any
 
 import pyarrow as pa
 
-from ._logging import setup_logger
-from ._schema import (
+from bids2table._logging import setup_logger
+from bids2table._schema import (
     SchemaSpec,
     decode_metadata,
     entity_arrow_schema,

--- a/bids2table/_entities.py
+++ b/bids2table/_entities.py
@@ -72,9 +72,13 @@ def parse_bids_entities(path: str | Path) -> dict[str, str]:
             key, val = part.split("-", maxsplit=1)
             entities[key] = val
 
-    for k, v in zip(["datatype", "suffix", "ext"], [datatype, suffix, ext]):
-        if v is not None:
-            entities[k] = v
+    entities |= {
+        k: v
+        for k, v in zip(
+            ["datatype", "suffix", "ext"], [datatype, suffix, ext], strict=True
+        )
+        if v is not None
+    }
     return entities
 
 
@@ -90,8 +94,7 @@ def _parse_bids_datatype(path: Path) -> str | None:
     (optionally) session directories. Returns `None` if no match found.
     """
     match = re.search(_BIDS_DATATYPE_PATTERN, str(path))
-    datatype = match.group(1) if match is not None else None
-    return datatype
+    return match.group(1) if match is not None else None
 
 
 def validate_bids_entities(
@@ -136,7 +139,7 @@ def _pyarrow_validate_entities(
                 value = typ(value)
             except ValueError:
                 _logger.warning(
-                    f"Unable to coerce {repr(value)} to type {typ} for entity '{name}'.",
+                    f"Unable to coerce {value!r} to type {typ} for entity '{name}'.",
                 )
                 extra_entities[name] = value
                 continue
@@ -210,5 +213,4 @@ def format_bids_path(entities: dict[str, Any], int_format: str = "%d") -> Path:
         path = datatype / path
     if ses := entities.get("ses"):
         path = f"ses-{ses}" / path
-    path = f"sub-{entities['sub']}" / path
-    return path
+    return f"sub-{entities['sub']}" / path

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -236,7 +236,7 @@ def index_dataset(
 
 
 def batch_index_dataset(
-    roots: list[str | PathT],
+    roots: Sequence[str | PathT],
     max_workers: int | None = 0,
     executor_cls: type[ProcessPoolExecutor | ThreadPoolExecutor] = ProcessPoolExecutor,
     *,

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -9,10 +9,11 @@ import fnmatch
 import importlib.metadata
 import re
 import sys
+from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
 from concurrent.futures import Executor, ProcessPoolExecutor
 from functools import lru_cache, partial
 from glob import glob
-from typing import Any, Callable, Generator, Iterable, Sequence
+from typing import Any
 
 import pyarrow as pa
 from tqdm import tqdm
@@ -122,7 +123,7 @@ def get_column_names(*, schema: SchemaSpec = None) -> enum.StrEnum:
         name = f.metadata[b"name"].decode()
         items.append((name, name))
 
-    BIDSColumn = enum.StrEnum("BIDSColumn", items)
+    BIDSColumn = enum.StrEnum("BIDSColumn", items)  # noqa: N806 - class type
     BIDSColumn.__doc__ = "Enum of BIDS index column names."
     return BIDSColumn
 
@@ -195,7 +196,6 @@ def find_bids_datasets(
 def index_dataset(
     root: str | PathT,
     include_subjects: str | list[str] | None = None,
-    show_progress: bool = False,
     *,
     schema: SchemaSpec = None,
 ) -> pa.Table:
@@ -205,7 +205,6 @@ def index_dataset(
         root: BIDS dataset root directory.
         include_subjects: Glob pattern or list of patterns for matching subjects to
             include in the index.
-        show_progress: Show progress bar.
         schema: BIDS schema specification to use. If ``None``, uses the bundled
             default schema.
 
@@ -233,16 +232,15 @@ def index_dataset(
         _, table = _index_bids_subject_dir(sub, schema=arrow_schema, dataset=dataset)
         tables.append(table)
         file_count += len(table)
-    table = pa.concat_tables(tables).combine_chunks()
-    return table
+    return pa.concat_tables(tables).combine_chunks()
 
 
 def batch_index_dataset(
     roots: list[str | PathT],
     max_workers: int | None = 0,
     executor_cls: type[Executor] = ProcessPoolExecutor,
-    show_progress: bool = False,
     *,
+    show_progress: bool = False,
     schema: SchemaSpec = None,
 ) -> Generator[pa.Table, None, None]:
     """Index a batch of BIDS datasets.
@@ -270,7 +268,7 @@ def batch_index_dataset(
         )
     ):
         file_count += len(table)
-        pbar.set_postfix(dict(ds=dataset, N=_hfmt(file_count)), refresh=False)
+        pbar.set_postfix({"ds": dataset, "N": _hfmt(file_count)}, refresh=False)
         yield table
 
 
@@ -282,7 +280,7 @@ def _batch_index_func(
     return dataset, table
 
 
-@lru_cache()
+@lru_cache
 def _get_bids_dataset(path: str | PathT) -> tuple[str | None, PathT | None]:
     """Get the BIDS dataset that the path belongs to, if any.
 
@@ -318,7 +316,7 @@ def _get_bids_dataset(path: str | PathT) -> tuple[str | None, PathT | None]:
     return dataset, root
 
 
-@lru_cache()
+@lru_cache
 def _is_bids_dataset(path: PathT) -> bool:
     """Test if path is a BIDS dataset root directory."""
     # Quick heuristic checks.
@@ -357,7 +355,7 @@ def _find_bids_subject_dirs(
 
     if include_subjects:
         filtered_names = _filter_include(
-            set(path.name for path in paths), include_subjects
+            {path.name for path in paths}, include_subjects
         )
         paths = [path for path in paths if path.name in filtered_names]
     return paths
@@ -395,7 +393,7 @@ def _index_bids_subject_dir(
         paths = map(as_path, path.rglob("sub-*", recurse_symlinks=True))
     else:
         # Fall back to glob.glob for <py3.13
-        paths = map(as_path, glob(f"{path}/**/sub-*", recursive=True))
+        paths = map(as_path, glob(f"{path}/**/sub-*", recursive=True))  # noqa: PTH207
 
     for p in paths:
         if _is_bids_file(p):
@@ -440,9 +438,7 @@ def _is_bids_file(path: PathT) -> bool:
     # very special case for directories that are treated as bids "files"
     # e.g. microscopy .ome.zarr directories or MEG .ds directories.
     # A little annoying that we have to do this.
-    if _is_bids_file(path.parent):
-        return False
-    return True
+    return not _is_bids_file(path.parent)
 
 
 def _is_bids_json_sidecar(path: PathT) -> bool:
@@ -466,9 +462,7 @@ def _is_bids_json_sidecar(path: PathT) -> bool:
     # All sidecars must contain a suffix.
     # Also check if suffix matches special cases of data files with json extension.
     suffix = entities.get("suffix")
-    if suffix is None or suffix in _BIDS_JSON_SIDECAR_EXCEPTION_SUFFIXES:
-        return False
-    return True
+    return not (suffix is None or suffix in _BIDS_JSON_SIDECAR_EXCEPTION_SUFFIXES)
 
 
 def _pmap(
@@ -477,7 +471,7 @@ def _pmap(
     max_workers: int | None = 0,
     chunksize: int = 1,
     executor_cls: type[Executor] = ProcessPoolExecutor,
-):
+) -> Iterator[Any]:
     if max_workers == 0:
         yield from map(func, iterable)
     else:

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -6,11 +6,10 @@ Returns a dataset index as an Arrow table.
 
 import enum
 import fnmatch
-import importlib.metadata
 import re
 import sys
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence
-from concurrent.futures import Executor, ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from functools import lru_cache, partial
 from glob import glob
 from typing import Any
@@ -25,6 +24,7 @@ from ._entities import (
 from ._logging import setup_logger
 from ._pathlib import CloudPath, PathT, as_path, cloudpathlib_is_available
 from ._schema import SchemaSpec, entity_arrow_schema, load_bids_schema
+from ._version import version
 
 _BIDS_SUBJECT_DIR_PATTERN = re.compile(r"sub-[a-zA-Z0-9]+")
 
@@ -106,12 +106,12 @@ def get_arrow_schema(*, schema: SchemaSpec = None) -> pa.Schema:
     ]
     metadata = {
         **entity_schema.metadata,
-        b"bids2table_version": importlib.metadata.version(__package__).encode(),
+        b"bids2table_version": version.encode(),
     }
     return pa.schema(fields, metadata=metadata)
 
 
-def get_column_names(*, schema: SchemaSpec = None) -> enum.StrEnum:
+def get_column_names(*, schema: SchemaSpec = None) -> type[enum.StrEnum]:
     """Get an enum of the BIDS index columns."""
     # TODO: It might be nice if the column names were statically available. One option
     # would be to generate a static _schema.py module at install time (similar to how
@@ -150,7 +150,7 @@ def find_bids_datasets(
         exclude = [exclude]
     elif exclude is None:
         exclude = []
-    exclude = [re.compile(fnmatch.translate(pat)) for pat in exclude]
+    exclude_patterns = [re.compile(fnmatch.translate(pat)) for pat in exclude]
 
     entry_count = 1
     ds_count = 0
@@ -171,7 +171,7 @@ def find_bids_datasets(
         for entry in top.iterdir():
             entry_count += 1
 
-            if any(re.fullmatch(pat, entry.name) for pat in exclude):
+            if any(re.fullmatch(pat, entry.name) for pat in exclude_patterns):
                 continue
 
             if _is_bids_dataset(entry):
@@ -238,7 +238,7 @@ def index_dataset(
 def batch_index_dataset(
     roots: list[str | PathT],
     max_workers: int | None = 0,
-    executor_cls: type[Executor] = ProcessPoolExecutor,
+    executor_cls: type[ProcessPoolExecutor | ThreadPoolExecutor] = ProcessPoolExecutor,
     *,
     show_progress: bool = False,
     schema: SchemaSpec = None,
@@ -276,7 +276,7 @@ def _batch_index_func(
     root: str | PathT, *, schema: SchemaSpec = None
 ) -> tuple[str | None, pa.Table]:
     dataset, _ = _get_bids_dataset(root)
-    table = index_dataset(root, show_progress=False, schema=schema)
+    table = index_dataset(root, schema=schema)
     return dataset, table
 
 
@@ -406,7 +406,9 @@ def _index_bids_subject_dir(
                 **valid_entities,
                 "extra_entities": extra_entities,
                 "root": root_fmt,
-                "path": str(p.relative_to(root)),
+                "path": str(  # `.relatve_to` available to both CloudPath and Path
+                    p.relative_to(root)  # ty:ignore[invalid-argument-type]
+                ),
             }
             records.append(record)
 
@@ -470,7 +472,7 @@ def _pmap(
     iterable: Iterable[Any],
     max_workers: int | None = 0,
     chunksize: int = 1,
-    executor_cls: type[Executor] = ProcessPoolExecutor,
+    executor_cls: type[ProcessPoolExecutor | ThreadPoolExecutor] = ProcessPoolExecutor,
 ) -> Iterator[Any]:
     if max_workers == 0:
         yield from map(func, iterable)
@@ -484,7 +486,7 @@ def _pmap(
 
 def _filter_include(
     names: Iterable[str],
-    patterns: str | list[str],
+    patterns: str | Iterable[str],
 ) -> set[str]:
     """Filter names including those that match a glob pattern or list of patterns."""
     names = set(names)
@@ -495,7 +497,7 @@ def _filter_include(
 
 def _filter_exclude(
     names: Iterable[str],
-    patterns: str | list[str],
+    patterns: str | Iterable[str],
 ) -> set[str]:
     """Filter names excluding those that match a glob pattern or list of patterns."""
     names = set(names)
@@ -504,7 +506,9 @@ def _filter_exclude(
     return names
 
 
-def _multi_pattern_filter(names: list[str], patterns: str | list[str]) -> set[str]:
+def _multi_pattern_filter(
+    names: Iterable[str], patterns: str | Iterable[str]
+) -> set[str]:
     """Filter names matching any of a list of patterns."""
     if isinstance(patterns, str):
         patterns = [patterns]

--- a/bids2table/_indexing.py
+++ b/bids2table/_indexing.py
@@ -17,14 +17,14 @@ from typing import Any
 import pyarrow as pa
 from tqdm import tqdm
 
-from ._entities import (
+from bids2table._entities import (
     _cache_parse_bids_entities,
     _pyarrow_validate_entities,
 )
-from ._logging import setup_logger
-from ._pathlib import CloudPath, PathT, as_path, cloudpathlib_is_available
-from ._schema import SchemaSpec, entity_arrow_schema, load_bids_schema
-from ._version import version
+from bids2table._logging import setup_logger
+from bids2table._pathlib import CloudPath, PathT, as_path, cloudpathlib_is_available
+from bids2table._schema import SchemaSpec, entity_arrow_schema, load_bids_schema
+from bids2table._version import version
 
 _BIDS_SUBJECT_DIR_PATTERN = re.compile(r"sub-[a-zA-Z0-9]+")
 

--- a/bids2table/_logging.py
+++ b/bids2table/_logging.py
@@ -4,11 +4,11 @@ import logging
 class RepetitiveFilter(logging.Filter):
     """Suppress similar log messages after a number of repeats."""
 
-    def __init__(self, max_repeats: int = 2):
+    def __init__(self, max_repeats: int = 2) -> None:
         self.max_repeats = max_repeats
         self._counts: dict[tuple[str, int, str], int] = {}
 
-    def filter(self, record: logging.LogRecord):
+    def filter(self, record: logging.LogRecord) -> bool:
         # Exact repeat of path, line, message.
         key = record.pathname, record.lineno, record.msg
         count = self._counts.get(key, 0) + 1
@@ -22,6 +22,7 @@ def setup_logger(
     name: str | None = None,
     level: int | str | None = None,
     max_repeats: int | None = 2,
+    *,
     overwrite: bool = False,
 ) -> logging.Logger:
     """Get logger with my preferred formatting and repetition filtering."""

--- a/bids2table/_metadata.py
+++ b/bids2table/_metadata.py
@@ -1,13 +1,14 @@
 import json
+from collections.abc import Generator
 from functools import lru_cache
-from typing import Any, Generator
+from typing import Any
 
 from ._entities import _cache_parse_bids_entities
 from ._indexing import _is_bids_dataset
 from ._pathlib import PathT, as_path
 
 
-def load_bids_metadata(path: str | PathT, inherit: bool = True) -> dict[str, Any]:
+def load_bids_metadata(path: str | PathT, *, inherit: bool = True) -> dict[str, Any]:
     """Load the full JSON sidecar metadata for a BIDS file.
 
     Sidecar files are loaded according to the inheritance principle in top-down order.
@@ -42,7 +43,7 @@ def load_bids_metadata(path: str | PathT, inherit: bool = True) -> dict[str, Any
 
 
 @lru_cache
-def _load_json(path: PathT) -> Any:
+def _load_json(path: PathT) -> Any:  # noqa: ANN401 - match return type of `json.loads`
     return json.loads(path.read_text())
 
 
@@ -83,7 +84,7 @@ def _find_bids_parents(
         parent = parent.parent
 
 
-@lru_cache()
+@lru_cache
 def _glob(path: PathT, pattern: str) -> list[PathT]:
     return list(path.glob(pattern))
 

--- a/bids2table/_metadata.py
+++ b/bids2table/_metadata.py
@@ -3,9 +3,9 @@ from collections.abc import Generator
 from functools import lru_cache
 from typing import Any
 
-from ._entities import _cache_parse_bids_entities
-from ._indexing import _is_bids_dataset
-from ._pathlib import PathT, as_path
+from bids2table._entities import _cache_parse_bids_entities
+from bids2table._indexing import _is_bids_dataset
+from bids2table._pathlib import PathT, as_path
 
 
 def load_bids_metadata(path: str | PathT, *, inherit: bool = True) -> dict[str, Any]:

--- a/bids2table/_pathlib.py
+++ b/bids2table/_pathlib.py
@@ -13,7 +13,7 @@ try:
         GSClient().set_as_default_client()
     # Using generalized Exception here, as DefaultCredentialsError is not available for
     # import if GSClient is not available
-    except Exception:
+    except Exception:  # noqa: S110 - catch-all for all GSC-related errors
         pass
 
 except Exception:

--- a/bids2table/_pathlib.py
+++ b/bids2table/_pathlib.py
@@ -17,7 +17,12 @@ try:
         pass
 
 except Exception:
-    AnyPath = CloudPath = Path
+    # Assignment of cloudpath classes if cloudpathlib is unavailable
+    class CloudPath(Path):
+        pass
+
+    class AnyPath(Path):
+        pass
 
     _CLOUDPATHLIB_AVAILABLE = False
 

--- a/bids2table/_schema.py
+++ b/bids2table/_schema.py
@@ -111,7 +111,7 @@ def _build_adapter_from_namespace(schema: Namespace) -> BIDSSchemaAdapter:
     )
 
 
-SchemaSpec: TypeAlias = Namespace | str | PathT | None
+SchemaSpec: TypeAlias = Namespace | str | PathT | None  # noqa: UP040 - req'd for py311
 
 
 @lru_cache
@@ -121,7 +121,7 @@ def _load_from_path(path: str | PathT | None) -> BIDSSchemaAdapter:
     return _build_adapter_from_namespace(schema)
 
 
-def load_bids_schema(spec: SchemaSpec = None) -> BIDSSchemaAdapter:
+def load_bids_schema(spec: SchemaSpec | None = None) -> BIDSSchemaAdapter:
     """Resolve a `SchemaSpec` to a `BIDSSchemaAdapter`.
 
     Hashable specs (`None`, `str`, `PathT`) hit a memoized loader.
@@ -131,7 +131,7 @@ def load_bids_schema(spec: SchemaSpec = None) -> BIDSSchemaAdapter:
     """
     if isinstance(spec, Namespace):
         return _build_adapter_from_namespace(spec)
-    if spec is None or isinstance(spec, (str, os.PathLike)):
+    if spec is None or isinstance(spec, str | os.PathLike):
         return _load_from_path(spec)
     raise TypeError(
         f"schema must be Namespace | str | PathT | None, got {type(spec).__name__}"

--- a/bids2table/pybids/__init__.py
+++ b/bids2table/pybids/__init__.py
@@ -2,9 +2,6 @@
 
 __all__ = ["BIDSFile", "BIDSLayout", "Query", "listify"]
 
-from ._bidsfile import BIDSFile
-from ._layout import BIDSLayout
-from ._utils import (
-    Query,
-    listify,
-)
+from bids2table.pybids._bidsfile import BIDSFile
+from bids2table.pybids._layout import BIDSLayout
+from bids2table.pybids._utils import Query, listify

--- a/bids2table/pybids/__init__.py
+++ b/bids2table/pybids/__init__.py
@@ -1,4 +1,6 @@
-__all__ = ["BIDSLayout", "BIDSFile", "Query", "listify"]
+"""PyBIDS compatability-layer module."""
+
+__all__ = ["BIDSFile", "BIDSLayout", "Query", "listify"]
 
 from ._bidsfile import BIDSFile
 from ._layout import BIDSLayout

--- a/bids2table/pybids/_bidsfile.py
+++ b/bids2table/pybids/_bidsfile.py
@@ -1,5 +1,4 @@
-"""
-BIDSFile wrapper for file paths with entity access.
+"""BIDSFile wrapper for file paths with entity access.
 
 Provides a PyBIDS-compatible file object that can parse and cache
 BIDS entities from file paths.
@@ -7,12 +6,11 @@ BIDS entities from file paths.
 
 from typing import Any
 
-from .._entities import parse_bids_entities
+from bids2table._entities import parse_bids_entities
 
 
 class BIDSFile:
-    """
-    Wrapper around a BIDS file path with entity parsing.
+    """Wrapper around a BIDS file path with entity parsing.
 
     Provides PyBIDS-compatible interface for accessing file entities.
     Entities are lazily parsed and cached on first access.
@@ -25,9 +23,8 @@ class BIDSFile:
         {'sub': '01', 'task': 'rest', 'suffix': 'bold', 'ext': '.nii.gz'}
     """
 
-    def __init__(self, path: str):
-        """
-        Initialize BIDSFile.
+    def __init__(self, path: str) -> None:
+        """Initialize BIDSFile.
 
         Args:
             path: Path to BIDS file (absolute or relative)
@@ -36,8 +33,7 @@ class BIDSFile:
         self._entities: dict[str, Any] | None = None
 
     def get_entities(self) -> dict[str, Any]:
-        """
-        Parse and return BIDS entities from filename.
+        """Parse and return BIDS entities from filename.
 
         Entities are cached after first parse for performance.
 
@@ -56,7 +52,7 @@ class BIDSFile:
         """Developer-friendly representation."""
         return f"BIDSFile('{self.path}')"
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Equality based on path."""
         if isinstance(other, BIDSFile):
             return self.path == other.path
@@ -66,30 +62,30 @@ class BIDSFile:
         """Allow use in sets/dicts."""
         return hash(self.path)
 
-    def __lt__(self, other) -> bool:
+    def __lt__(self, other: object) -> bool:
         """Less-than comparison based on path (for sorting)."""
         if isinstance(other, BIDSFile):
             return self.path < other.path
         return NotImplemented
 
-    def __le__(self, other) -> bool:
+    def __le__(self, other: object) -> bool:
         """Less-than-or-equal comparison based on path."""
         if isinstance(other, BIDSFile):
             return self.path <= other.path
         return NotImplemented
 
-    def __gt__(self, other) -> bool:
+    def __gt__(self, other: object) -> bool:
         """Greater-than comparison based on path."""
         if isinstance(other, BIDSFile):
             return self.path > other.path
         return NotImplemented
 
-    def __ge__(self, other) -> bool:
+    def __ge__(self, other: object) -> bool:
         """Greater-than-or-equal comparison based on path."""
         if isinstance(other, BIDSFile):
             return self.path >= other.path
         return NotImplemented
 
-    def __contains__(self, item) -> bool:
+    def __contains__(self, item: str) -> bool:
         """Check if substring is in the file path (for 'in' operator)."""
         return item in self.path

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -54,7 +54,7 @@ class BIDSLayout:
         database_path: Path | None = None,
         *,
         reset_database: bool = False,
-        **kwargs: dict[str, Any],  # noqa: ARG002 - allow for other kwargs to be passed
+        **kwargs: Any,  # noqa: ANN401, ARG002 - additional kwargs (any type) can be passed
     ) -> None:
         # Initialize BIDSLayout with dataset indexing.
         self.root = Path(root).absolute()
@@ -192,7 +192,9 @@ class BIDSLayout:
             self._tab = pa.concat_tables([self._tab, *deriv_tabs])
 
     def get(
-        self, return_type: str = "file", **entities: dict[str, Any]
+        self,
+        return_type: str = "file",
+        **entities: str | int,
     ) -> list[str | BIDSFile]:
         """Query files by BIDS entities.
 
@@ -206,7 +208,7 @@ class BIDSLayout:
         result_df = self._filter_df(entities)
         return self._format_results(result_df, return_type)
 
-    def _filter_df(self, entities: dict[str, Any]) -> pd.DataFrame:
+    def _filter_df(self, entities: dict[str, str | int]) -> pd.DataFrame:
         """Apply entity filters to dataframe."""
         result_df = self.df
         for key, value in entities.items():
@@ -225,7 +227,7 @@ class BIDSLayout:
         self,
         df: pd.DataFrame,
         key: str,
-        value: Any,  # noqa: ANN401
+        value: Query | list[str | int] | str | int,
     ) -> pd.DataFrame:
         """Apply single entity filter, handling Query sentinels."""
         if value in (Query.OPTIONAL, Query.ANY):
@@ -239,23 +241,22 @@ class BIDSLayout:
     def _format_results(
         self, df: pd.DataFrame, return_type: str
     ) -> list[str | BIDSFile]:
-        """Convert filtered dataframe to requested return type."""
-        formatters = {
-            "filename": lambda d: d["path"].tolist(),
-            "file": lambda d: [BIDSFile(p) for p in d["path"].tolist()],
-            "id": lambda d: d.index.tolist(),
-            "dir": lambda d: sorted(
-                d["path"].apply(lambda p: str(Path(p).parent)).unique().tolist()
-            ),
-        }
-        if return_type not in formatters:
-            raise ValueError(
-                f"Unknown return_type: {return_type}. "
-                "Valid options: 'file', 'filename', 'id', 'dir'"
+        if return_type == "filename":
+            return df["path"].tolist()
+        if return_type == "file":
+            return [BIDSFile(p) for p in df["path"].tolist()]
+        if return_type == "id":
+            return [str(x) for x in df.index.tolist()]
+        if return_type == "dir":
+            return sorted(
+                df["path"].apply(lambda p: str(Path(p).parent)).unique().tolist()
             )
-        return formatters[return_type](df)
+        raise ValueError(
+            f"Unknown return_type: {return_type}. "
+            "Valid options: 'file', 'filename', 'id', 'dir'"
+        )
 
-    def get_subjects(self, **filters: dict[str, str | int]) -> list[str]:
+    def get_subjects(self, **filters: str | int) -> list[str]:
         """Get list of unique subject IDs.
 
         Args:
@@ -284,7 +285,7 @@ class BIDSLayout:
         return sorted(subjects.tolist())
 
     def get_sessions(
-        self, subject: str | None = None, **filters: dict[str, str | int]
+        self, subject: str | None = None, **filters: str | int
     ) -> list[str]:
         """Get list of unique session IDs.
 
@@ -309,7 +310,7 @@ class BIDSLayout:
 
         # Apply additional filters
         for key, value in filters.items():
-            key = self._map_entity_key(key)
+            key = self._entity_map.get(key, key)
             if key in result_df.columns:
                 result_df = result_df[result_df[key] == value]
 
@@ -354,7 +355,7 @@ class BIDSLayout:
         """
         return BIDSFile(path)
 
-    def get_entities(self, **filters: dict[str, str | int]) -> dict[str, list[str]]:
+    def get_entities(self, **filters: str | int) -> dict[str, list[str]]:
         """Get dictionary of all entities and their unique values.
 
         Args:
@@ -376,7 +377,7 @@ class BIDSLayout:
         if filters:
             filtered_df = self.df.copy()
             for key, value in filters.items():
-                key = self._map_entity_key(key)
+                key = self._entity_map.get(key, key)
                 if key in filtered_df.columns:
                     filtered_df = filtered_df[filtered_df[key] == value]
         else:
@@ -395,7 +396,7 @@ class BIDSLayout:
     def add_custom_entity(
         self,
         name: str,
-        values: list[Any] | dict[str, Any] | Any,  # noqa: ANN401 - custom entities
+        values: list[str | int] | dict[str, str | int] | str | int,
         *,
         overwrite: bool = False,
     ) -> None:

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -5,6 +5,7 @@ while leveraging bids2table's superior performance.
 """
 
 import warnings
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -193,7 +194,7 @@ class BIDSLayout:
     def get(
         self,
         return_type: str = "file",
-        **entities: str | int,
+        **entities: Sequence[str | int] | str | int | Query,
     ) -> list[str | BIDSFile]:
         """Query files by BIDS entities.
 
@@ -207,7 +208,9 @@ class BIDSLayout:
         result_df = self._filter_df(entities)
         return self._format_results(result_df, return_type)
 
-    def _filter_df(self, entities: dict[str, str | int]) -> pd.DataFrame:
+    def _filter_df(
+        self, entities: dict[str, Sequence[str | int] | str | int | Query]
+    ) -> pd.DataFrame:
         """Apply entity filters to dataframe."""
         result_df = self.df
         for key, value in entities.items():
@@ -226,7 +229,7 @@ class BIDSLayout:
         self,
         df: pd.DataFrame,
         key: str,
-        value: Query | list[str | int] | str | int,
+        value: Sequence[str | int] | str | int | Query,
     ) -> pd.DataFrame:
         """Apply single entity filter, handling Query sentinels."""
         if value in (Query.OPTIONAL, Query.ANY):
@@ -395,7 +398,7 @@ class BIDSLayout:
     def add_custom_entity(
         self,
         name: str,
-        values: list[str | int] | dict[str, str | int] | str | int,
+        values: list[str | int] | dict[str, str | int] | str | int | Callable,
         *,
         overwrite: bool = False,
     ) -> None:

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -1,5 +1,4 @@
-"""
-BIDSLayout compatibility wrapper around bids2table.
+"""BIDSLayout compatibility wrapper around bids2table.
 
 Provides a PyBIDS-compatible interface for querying BIDS datasets
 while leveraging bids2table's superior performance.
@@ -13,15 +12,15 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from .._indexing import index_dataset
-from .._metadata import load_bids_metadata
+from bids2table._indexing import index_dataset
+from bids2table._metadata import load_bids_metadata
+
 from ._bidsfile import BIDSFile
 from ._utils import Query
 
 
 class BIDSLayout:
-    """
-    PyBIDS-compatible wrapper around bids2table.
+    """PyBIDS-compatible wrapper around bids2table.
 
     Provides a familiar BIDSLayout interface while using bids2table's
     fast indexing and efficient querying under the hood.
@@ -35,9 +34,11 @@ class BIDSLayout:
     Args:
         root: Path to BIDS dataset root
         derivatives: Path(s) to derivative datasets to include
-        cache_path: Path to parquet cache file (default: {root}/.bids2table_cache.parquet)
+        cache_path: Path to parquet cache file
+            (default: {root}/.bids2table_cache.parquet)
         database_path: Legacy parameter (ignored, use cache_path instead)
-        reset_database: If True, ignore cache and force re-indexing (useful for benchmarking)
+        reset_database: If True, ignore cache and force re-indexing
+            (useful for benchmarking)
         **kwargs: Additional arguments (currently ignored)
 
     Attributes:
@@ -51,9 +52,10 @@ class BIDSLayout:
         derivatives: str | Path | list[str | Path] | None = None,
         cache_path: Path | None = None,
         database_path: Path | None = None,
+        *,
         reset_database: bool = False,
-        **kwargs,
-    ):
+        **kwargs: dict[str, Any],  # noqa: ARG002 - allow for other kwargs to be passed
+    ) -> None:
         # Initialize BIDSLayout with dataset indexing.
         self.root = Path(root).absolute()
         self.reset_database = reset_database
@@ -124,13 +126,11 @@ class BIDSLayout:
         self._tab = self._tab.select(cols)
 
     def _load_or_create_index(self) -> pa.Table:
-        """
-        Load cached index or create new one.
+        """Load cached index or create new one.
 
         Returns:
             PyArrow table with indexed BIDS files
         """
-
         # If reset_database is True, skip cache and force re-index
         if not self.reset_database and self.cache_path.exists():
             # Check if cache is stale (optional - could be expensive)
@@ -162,9 +162,8 @@ class BIDSLayout:
 
         return tab
 
-    def _add_derivatives(self, derivatives: str | Path | list[str | Path]):
-        """
-        Add derivative datasets to the index.
+    def _add_derivatives(self, derivatives: str | Path | list[str | Path]) -> None:
+        """Add derivative datasets to the index.
 
         Args:
             derivatives: Path or list of paths to derivative datasets
@@ -190,84 +189,74 @@ class BIDSLayout:
 
         # Concatenate with main table
         if deriv_tabs:
-            self._tab = pa.concat_tables([self._tab] + deriv_tabs)
+            self._tab = pa.concat_tables([self._tab, *deriv_tabs])
 
-    def get(self, return_type: str = "file", **entities) -> list[str | BIDSFile]:
-        """
-        Query files by BIDS entities.
+    def get(
+        self, return_type: str = "file", **entities: dict[str, Any]
+    ) -> list[str | BIDSFile]:
+        """Query files by BIDS entities.
 
         Args:
-            return_type: Type of return value:
-                - 'file': List of BIDSFile objects
-                - 'filename': List of path strings
-                - 'id': List of row indices
-                - 'dir': List of unique directories
+            return_type: 'file', 'filename', 'id', or 'dir'
             **entities: BIDS entity filters (e.g., subject='01', suffix='T1w')
 
         Returns:
             List of files matching query (type depends on return_type)
-
-        Example:
-            >>> files = layout.get(subject='01', suffix='T1w', return_type='filename')
-            >>> ['sub-01/anat/sub-01_T1w.nii.gz']
         """
-        # Start with full dataframe
-        result_df = self.df.copy()
+        result_df = self._filter_df(entities)
+        return self._format_results(result_df, return_type)
 
-        # Apply filters
+    def _filter_df(self, entities: dict[str, Any]) -> pd.DataFrame:
+        """Apply entity filters to dataframe."""
+        result_df = self.df
         for key, value in entities.items():
-            # Map common PyBIDS names to b2t column names
-            # PyBIDS uses 'subject', 'session', 'extension'
-            # b2t uses 'sub', 'ses', 'ext'
-            # Fallback to the current key if it's not in the dict
             key = self._entity_map.get(key, key)
-
-            # Check if column exists
             if key not in result_df.columns:
-                # Unknown entity - could warn or ignore
                 warnings.warn(
                     f"Unknown entity '{key}' (not in dataset columns)",
                     UserWarning,
                     stacklevel=2,
                 )
                 continue
+            result_df = self._apply_filter(result_df, key, value)
+        return result_df
 
-            # Handle special Query values
-            if value is Query.OPTIONAL:
-                # Allow any value (including missing) - no filtering
-                continue
-            elif value is Query.NONE:
-                # Match explicit nulls
-                result_df = result_df[result_df[key].isna()]
-            elif value is Query.ANY:
-                # Match any value - don't filter
-                continue
-            elif isinstance(value, list):
-                # List of values - use isin()
-                result_df = result_df[result_df[key].isin(value)]
-            else:
-                # Single value - exact match
-                result_df = result_df[result_df[key] == value]
+    def _apply_filter(
+        self,
+        df: pd.DataFrame,
+        key: str,
+        value: Any,  # noqa: ANN401
+    ) -> pd.DataFrame:
+        """Apply single entity filter, handling Query sentinels."""
+        if value in (Query.OPTIONAL, Query.ANY):
+            return df
+        if value is Query.NONE:
+            return df[df[key].isna()]
+        if isinstance(value, list):
+            return df[df[key].isin(value)]
+        return df[df[key] == value]
 
-        # Return based on return_type
-        if return_type == "filename":
-            return result_df["path"].tolist()
-        elif return_type == "file":
-            return [BIDSFile(p) for p in result_df["path"].tolist()]
-        elif return_type == "id":
-            return result_df.index.tolist()
-        elif return_type == "dir":
-            dirs = result_df["path"].apply(lambda p: str(Path(p).parent))
-            return sorted(dirs.unique().tolist())
-        else:
+    def _format_results(
+        self, df: pd.DataFrame, return_type: str
+    ) -> list[str | BIDSFile]:
+        """Convert filtered dataframe to requested return type."""
+        formatters = {
+            "filename": lambda d: d["path"].tolist(),
+            "file": lambda d: [BIDSFile(p) for p in d["path"].tolist()],
+            "id": lambda d: d.index.tolist(),
+            "dir": lambda d: sorted(
+                d["path"].apply(lambda p: str(Path(p).parent)).unique().tolist()
+            ),
+        }
+        if return_type not in formatters:
             raise ValueError(
                 f"Unknown return_type: {return_type}. "
                 "Valid options: 'file', 'filename', 'id', 'dir'"
             )
+        return formatters[return_type](df)
 
-    def get_subjects(self, **filters) -> list[str]:
-        """
-        Get list of unique subject IDs.
+    def get_subjects(self, **filters: dict[str, str | int]) -> list[str]:
+        """Get list of unique subject IDs.
 
         Args:
             **filters: Optional entity filters to apply before extracting subjects
@@ -294,9 +283,10 @@ class BIDSLayout:
 
         return sorted(subjects.tolist())
 
-    def get_sessions(self, subject: str | None = None, **filters) -> list[str]:
-        """
-        Get list of unique session IDs.
+    def get_sessions(
+        self, subject: str | None = None, **filters: dict[str, str | int]
+    ) -> list[str]:
+        """Get list of unique session IDs.
 
         Args:
             subject: Optional subject ID to filter by
@@ -327,8 +317,7 @@ class BIDSLayout:
         return sorted(sessions.tolist())
 
     def get_metadata(self, path: str) -> dict[str, Any]:
-        """
-        Load metadata from JSON sidecar(s) for a given file.
+        """Load metadata from JSON sidecar(s) for a given file.
 
         Uses BIDS inheritance principle to merge metadata from
         dataset, subject, and session levels.
@@ -343,7 +332,7 @@ class BIDSLayout:
             >>> metadata = layout.get_metadata('sub-01/func/sub-01_task-rest_bold.nii.gz')
             >>> metadata['RepetitionTime']
             2.0
-        """
+        """  # noqa: E501
         # Convert to absolute path if relative
         if not Path(path).is_absolute():
             path = str(self.root / path)
@@ -351,8 +340,7 @@ class BIDSLayout:
         return load_bids_metadata(path)
 
     def get_file(self, path: str) -> BIDSFile:
-        """
-        Get BIDSFile object for a given path.
+        """Get BIDSFile object for a given path.
 
         Args:
             path: Path to file
@@ -366,9 +354,8 @@ class BIDSLayout:
         """
         return BIDSFile(path)
 
-    def get_entities(self, **filters) -> dict[str, list[str]]:
-        """
-        Get dictionary of all entities and their unique values.
+    def get_entities(self, **filters: dict[str, str | int]) -> dict[str, list[str]]:
+        """Get dictionary of all entities and their unique values.
 
         Args:
             **filters: Optional entity filters to apply before extracting entities
@@ -397,7 +384,7 @@ class BIDSLayout:
 
         # Extract unique values for each entity column
         entities = {}
-        for ekey, evalue in self._entity_map.items():
+        for evalue in self._entity_map.values():
             if evalue in filtered_df.columns:
                 unique_vals = filtered_df[evalue].dropna().unique().tolist()
                 if unique_vals:  # Only include if not empty
@@ -408,11 +395,11 @@ class BIDSLayout:
     def add_custom_entity(
         self,
         name: str,
-        values: list[Any] | dict[str, Any] | Any,
+        values: list[Any] | dict[str, Any] | Any,  # noqa: ANN401 - custom entities
+        *,
         overwrite: bool = False,
-    ):
-        """
-        Add a custom entity column to the layout.
+    ) -> None:
+        """Add a custom entity column to the layout.
 
         This is a convenience method for adding custom metadata that can be
         queried like standard BIDS entities.
@@ -447,21 +434,19 @@ class BIDSLayout:
                 f"Entity '{name}' already exists. Use overwrite=True to replace."
             )
 
-        # Handle different value types
         if callable(values):
-            # Function: apply to each row
             self.df[name] = self.df.apply(values, axis=1)
         elif isinstance(values, dict):
-            # Dict: map from key (assume subject or file path)
-            # Try to detect if keys are subjects or paths
-            if values and list(values.keys())[0] in self.df["sub"].values:
-                # Keys are subjects
-                self.df[name] = self.df["sub"].map(values)
+            if values:
+                first_key = next(iter(values))
+                sub_col = self.df["sub"]
+                map_col = (
+                    sub_col if first_key in sub_col.to_numpy() else self.df["path"]
+                )
             else:
-                # Keys are file paths or other
-                self.df[name] = self.df["path"].map(values)
+                map_col = self.df["path"]
+            self.df[name] = map_col.map(values)
         else:
-            # Scalar or array-like: assign directly
             self.df[name] = values
 
         self._entity_map[name] = name

--- a/bids2table/pybids/_layout.py
+++ b/bids2table/pybids/_layout.py
@@ -14,9 +14,8 @@ import pyarrow.parquet as pq
 
 from bids2table._indexing import index_dataset
 from bids2table._metadata import load_bids_metadata
-
-from ._bidsfile import BIDSFile
-from ._utils import Query
+from bids2table.pybids._bidsfile import BIDSFile
+from bids2table.pybids._utils import Query
 
 
 class BIDSLayout:

--- a/bids2table/pybids/_utils.py
+++ b/bids2table/pybids/_utils.py
@@ -11,13 +11,12 @@ class Query:
     NONE = object()  # Match explicit null/missing
     ANY = object()  # Match any value (don't filter)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Query"
 
 
-def listify(obj: Any) -> list:
-    """
-    Convert an object to a list if it isn't already one.
+def listify(obj: Any) -> list:  # noqa: ANN401 - passed object can be anything
+    """Convert an object to a list if it isn't already one.
 
     This is a PyBIDS utility function that niworkflows and other packages use.
 
@@ -26,14 +25,14 @@ def listify(obj: Any) -> list:
     obj : Any
         Object to convert to list
 
-    Returns
+    Returns:
     -------
     list
         If obj is None, returns empty list
         If obj is already a list/tuple, returns as list
         Otherwise returns [obj]
 
-    Examples
+    Examples:
     --------
     >>> listify(None)
     []
@@ -46,7 +45,6 @@ def listify(obj: Any) -> list:
     """
     if obj is None:
         return []
-    elif isinstance(obj, (list, tuple)):
+    if isinstance(obj, list | tuple):
         return list(obj)
-    else:
-        return [obj]
+    return [obj]

--- a/bids2table/pybids/_utils.py
+++ b/bids2table/pybids/_utils.py
@@ -1,15 +1,16 @@
 """Utility functions for PyBIDS compatibility."""
 
+from enum import Enum, auto
 from typing import Any
 
 
-class Query:
+class Query(Enum):
     """Special query values for entity filtering."""
 
     # Sentinel objects for special filtering behavior
-    OPTIONAL = object()  # Allow missing or any value
-    NONE = object()  # Match explicit null/missing
-    ANY = object()  # Match any value (don't filter)
+    OPTIONAL = auto()  # Allow missing or any value
+    NONE = auto()  # Match explicit null/missing
+    ANY = auto()  # Match any value (don't filter)
 
     def __repr__(self) -> str:
         return "Query"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,14 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT License" }
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Scientific/Engineering",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX",
     "Operating System :: Unix",
@@ -48,6 +49,7 @@ dev = [
     "pytest-benchmark>=5.2.3",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.13",
+    "ty>=0.0.53",
 ]
 
 [project.urls]
@@ -66,8 +68,48 @@ version_file = "bids2table/_version.py"
 
 [tool.ruff]
 line-length = 88
+indent-width = 4
+src = ["bids2table"]
 target-version = "py312"
-lint.extend-select = ["I"]
+
+[tool.ruff.lint]
+select = [
+  "ANN",  # flake8-annotations
+  "ARG",  # flake8-unused-arguments
+  "B",  # flake8-bugbear
+  "C4",  # flake8-comprehensions
+  "C90",  # mccabe
+  "D",  # pydocstyle
+  "E",  # pycodestyle errors
+  "ERA",  # eradicate
+  "F",  # Pyflakes
+  "FA",  # flake8-future-annotations
+  "FBT",  # flake8-boolean-trap
+  "FURB",  # refurb
+  "I",  # isort
+  "N",  # pep8-naming
+  "NPY",  # NumPy-specific rules
+  "PD",  # pandas-vet
+  "PERF",  # Perflint
+  "PIE",  # flake8-pie
+  "PT",  # flake8-pytest-style
+  "PTH",  # flake8-use-pathlib
+  "Q",  # flake8-quotes
+  "RET",  # flake8-return
+  "RUF",  # Ruff-specific rules
+  "S",  # flake8-bandit
+  "SIM",  # flake8-simplify
+  "T20",  # flake8-print
+  "TID",  # flake8-tidy-imports
+  "TC",  # flake8-type-checking
+  "UP"  # pyupgrade
+]
+ignore = []
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,51 +6,38 @@ build-backend = "setuptools.build_meta"
 name = "bids2table"
 dynamic = ["version"]
 authors = [
-  { name = "Connor Lane", email = "connor.lane858@gmail.com" },
-  { name = "Jason Kai" },
-  { name = "Florian Rupprecht" },
-  { name = "Gregory Kiar" }
+  {name = "Connor Lane", email = "connor.lane858@gmail.com"},
+  {name = "Jason Kai"},
+  {name = "Florian Rupprecht"},
+  {name = "Gregory Kiar"}
 ]
 description = "Index BIDS datasets fast, locally or in the cloud."
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT License" }
+license = {text = "MIT License"}
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Topic :: Scientific/Engineering",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: POSIX",
-    "Operating System :: Unix",
-    "Operating System :: MacOS",
-    "Operating System :: Microsoft :: Windows",
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Topic :: Scientific/Engineering",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: POSIX",
+  "Operating System :: Unix",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows"
 ]
-
 dependencies = ["bidsschematools>=1.0", "pyarrow>=24.0.0", "tqdm>=4.67.3"]
 
 [project.optional-dependencies]
 cloud = ["cloudpathlib[s3,gs]>=0.21.0"]
 s3 = [
-    "cloudpathlib[s3]>=0.21.0",
-] # Include s3 to not break backwards compatibility
+  "cloudpathlib[s3]>=0.21.0"
+]  # Include s3 to not break backwards compatibility
 pybids = ["pandas>=2.0.0"]
-
-[dependency-groups]
-dev = [
-    "pdoc>=16.0.0",
-    "polars>=1.40.1",
-    "pre-commit>=4.6.0",
-    "pytest>=9.0.3",
-    "pytest-benchmark>=5.2.3",
-    "pytest-cov>=7.1.0",
-    "ruff>=0.15.13",
-    "ty>=0.0.53",
-]
 
 [project.urls]
 "Homepage" = "https://github.com/childmindresearch/bids2table"
@@ -59,6 +46,18 @@ dev = [
 [project.scripts]
 bids2table = "bids2table.__main__:main"
 b2t2 = "bids2table.__main__:main"
+
+[dependency-groups]
+dev = [
+  "pdoc>=16.0.0",
+  "polars>=1.40.1",
+  "pre-commit>=4.6.0",
+  "pytest>=9.0.3",
+  "pytest-benchmark>=5.2.3",
+  "pytest-cov>=7.1.0",
+  "ruff>=0.15.13",
+  "ty>=0.0.53"
+]
 
 [tool.setuptools.packages.find]
 include = ["bids2table*"]
@@ -113,17 +112,23 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
-    "ANN201", # return annotation in public function
-    "ANN202", # return annotation in private function
-    "S101" # assert usage
+  "ANN201",  # return annotation in public function
+  "ANN202",  # return annotation in private function
+  "S101"  # assert usage
 ]
 "__init__.py" = ["F401", "F403"]
+
+[tool.ty.src]
+include = [
+  "bids2table",
+  "tests"
+]
 
 [tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "INFO"
 addopts = "--import-mode=importlib"
 markers = [
-    "benchmark: Tests used for benchmarking",
-    "cloud: Tests requiring cloud group dependencies",
+  "benchmark: Tests used for benchmarking",
+  "cloud: Tests requiring cloud group dependencies"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,11 @@ unfixable = []
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "ANN201", # return annotation in public function
+    "ANN202", # return annotation in private function
+    "S101" # assert usage
+]
 "__init__.py" = ["F401", "F403"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["bids2table*"]
+include = ["bids2table"]
 
 [tool.setuptools_scm]
 version_file = "bids2table/_version.py"
@@ -68,7 +68,10 @@ version_file = "bids2table/_version.py"
 [tool.ruff]
 line-length = 88
 indent-width = 4
-src = ["bids2table"]
+src = [
+  "bids2table",
+  "tests"
+]
 target-version = "py312"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ convention = "google"
   "ANN202",  # return annotation in private function
   "S101"  # assert usage
 ]
-"__init__.py" = ["F401", "F403"]
 
 [tool.ty.src]
 include = [

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -18,23 +18,37 @@ import argparse
 import json
 import logging
 import os
+import shutil
 import statistics
 import subprocess
 import sys
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import pytest
+
+if TYPE_CHECKING:
+    from types import GeneratorType
 
 logging.basicConfig(level=logging.INFO)
 _logger = logging.getLogger("bids2table.benchmark")
 
+# Resolve git path once at import time
+_git_path = shutil.which("git")
+if _git_path is None:
+    raise RuntimeError("git binary not found in PATH")
+_GIT = _git_path
 
-# Suppression and resetting (after checkout) necessary due to streaming of outputs
+
 @contextmanager
-def _suppress_log_exceptions():
+def _suppress_log_exceptions() -> GeneratorType:
+    """Temporarily disable logging exception raises.
+
+    Suppression and resetting (after checkout) are necessary due to streaming
+    of outputs during benchmark runs.
+    """
     logging.raiseExceptions = False
     try:
         yield
@@ -42,7 +56,8 @@ def _suppress_log_exceptions():
         logging.raiseExceptions = True
 
 
-def _reset_logger():
+def _reset_logger() -> None:
+    """Clear existing handlers and reconfigure the logger for a fresh checkout."""
     for h in _logger.handlers[:]:
         _logger.removeHandler(h)
         h.close()
@@ -52,12 +67,13 @@ def _reset_logger():
 class Git:
     """Class to simplify git calls via subprocess."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the repository object, pulling in latest changes."""
         self.repo_path = self._root()
         self._head_ref = self._run("rev-parse", "--abbrev-ref", "HEAD")
 
-    def __enter__(self):
+    def __enter__(self) -> Git:
+        """Verify clean working tree, pull latest, and update submodules."""
         if bool(self._run("status", "--porcelain")):
             _logger.error("Please stash or commit changes before benchmarking.")
             sys.exit(1)
@@ -65,20 +81,33 @@ class Git:
         self.submodule_update()
         return self
 
-    def __exit__(self, *_):
+    def __exit__(self, *_: Any) -> None:  # noqa: ANN401
         """On context closure, checkout the HEAD ref."""
         self.checkout(self._head_ref)
 
     @staticmethod
     def _root() -> Path:
-        result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+        """Return the top-level directory of the git repository."""
+        result = subprocess.run(  # noqa: S603
+            [_GIT, "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
         )
         return Path(result.stdout.strip())
 
     def _run(self, *args: str) -> str:
-        result = subprocess.run(
-            ["git", "-C", str(self.repo_path), *args], capture_output=True, text=True
+        """Execute a git command and return stripped stdout.
+
+        Args:
+            *args: Git subcommand and its arguments.
+
+        Raises:
+            SystemExit: If the git command returns a non-zero exit code.
+        """
+        result = subprocess.run(  # noqa: S603
+            [_GIT, "-C", str(self.repo_path), *args],
+            capture_output=True,
+            text=True,
         )
         if result.returncode != 0:
             _logger.error(result.stderr.strip())
@@ -111,6 +140,19 @@ class Git:
 
 
 class BenchmarkResult(NamedTuple):
+    """Holds statistics for a single benchmark run.
+
+    Attributes:
+        fullname: Full pytest identifier for the benchmark.
+        kind: Either "index" for indexing benchmarks or "query" for query benchmarks.
+        locality: Data locality for index benchmarks ("local" or "remote");
+            ``None`` for queries.
+        workers: Number of parallel workers for index benchmarks; ``1`` for queries.
+        median: Median execution time (seconds).
+        mean: Mean execution time (seconds).
+        stddev: Standard deviation of execution times (seconds).
+    """
+
     fullname: str
     kind: Literal["index", "query"]
     locality: Literal["local", "remote"] | None = None
@@ -121,6 +163,14 @@ class BenchmarkResult(NamedTuple):
 
 
 def parse_file(path: Path) -> dict[str, BenchmarkResult]:
+    """Parse a pytest-benchmark JSON file into a dict of results.
+
+    Args:
+        path: Path to the JSON output produced by ``--benchmark-json``.
+
+    Returns:
+        A dict mapping benchmark fullnames to their ``BenchmarkResult`` entries.
+    """
     data = json.loads(path.read_text())
     results = {}
     for benchmark in data["benchmarks"]:
@@ -152,25 +202,34 @@ def parse_file(path: Path) -> dict[str, BenchmarkResult]:
     return results
 
 
-# Values are alwaays provided in seconds in the json outputs.
+# Values are always provided in seconds in the JSON outputs.
 # Need to scale appropriately (also noting factor and unit to pass along for
 # formatting).
 class Value(NamedTuple):
+    """Scaled time value with its display unit.
+
+    Attributes:
+        value: The time value scaled to the chosen unit.
+        factor: The multiplier used to scale from seconds (e.g., 1e3 for ms).
+        unit: Human-readable unit label ("s", "ms", or "µs").
+    """
+
     value: float
     factor: float
     unit: str
 
 
 def _scale(val: float) -> Value:
+    """Scale a time value (seconds) to the most appropriate unit."""
     if val >= 1.0:
         return Value(value=val, factor=1, unit="s")
-    elif val >= 1e-3:
+    if val >= 1e-3:
         return Value(value=val * 1e3, factor=1e3, unit="ms")
-    else:
-        return Value(value=val * 1e6, factor=1e6, unit="µs")
+    return Value(value=val * 1e6, factor=1e6, unit="µs")
 
 
 def _fmt(res: BenchmarkResult) -> str:
+    """Format a benchmark result as a human-readable string (median, mean ± std)."""
     median = _scale(res.median)
     mean = res.mean * median.factor
     stddev = res.stddev * median.factor
@@ -178,6 +237,11 @@ def _fmt(res: BenchmarkResult) -> str:
 
 
 def _ratio(pr: BenchmarkResult, ref: BenchmarkResult, threshold: float) -> str:
+    """Compute the median ratio between two results with a status icon.
+
+    Returns a string like `"🔴 1.050"` (slower), `"⚪ 1.010"` (within threshold),
+    or `"🟢 0.950"` (faster).
+    """
     ratio = pr.median / ref.median
     if abs(1 - ratio) <= threshold:
         icon = "⚪"
@@ -189,6 +253,7 @@ def _ratio(pr: BenchmarkResult, ref: BenchmarkResult, threshold: float) -> str:
 
 
 def _label(result: BenchmarkResult) -> str:
+    """Produce a human-readable label for a benchmark result."""
     if result.kind == "query":
         return (
             result.fullname.split("::")[-1]
@@ -196,6 +261,8 @@ def _label(result: BenchmarkResult) -> str:
             .replace("_", " ")
             .capitalize()
         )
+    if result.locality is None:
+        raise ValueError("No result found for indexing")
     return f"{result.locality.capitalize()} index ({result.workers} workers)"
 
 
@@ -206,12 +273,24 @@ def build_table(
     main: dict[str, BenchmarkResult],
     tag: dict[str, BenchmarkResult] | None = None,
 ) -> str:
+    """Build a Markdown table comparing benchmark results across branches.
+
+    Args:
+        threshold: Fractional threshold below which a ratio is considered unchanged.
+        branch_name: Human-readable name of the feature branch.
+        branch: Parsed benchmark results for the feature branch.
+        main: Parsed benchmark results for ``main``.
+        tag: Optional parsed benchmark results for the last tag.
+
+    Returns:
+        A Markdown string containing the comparison table.
+    """
     tag = tag or {}
     all_keys = sorted(
         set(branch) | set(main) | set(tag),
         key=lambda x: (0 if "index" in x else 1 if "query" in x else 2, x),
     )
-    labels = [_label(branch.get(k) or main.get(k) or tag.get(k)) for k in all_keys]
+    labels = [_label(branch.get(k) or main.get(k) or tag.get(k)) for k in all_keys]  # ty: ignore[invalid-argument-type] - temporary until tag benchmark
 
     col_sep = " | "
     header = "| |" + col_sep.join(f" **{label}** " for label in labels) + " |"
@@ -246,6 +325,7 @@ def build_table(
 
 
 def _parser() -> argparse.Namespace:
+    """Build and parse command-line arguments for the benchmark script."""
     parser = argparse.ArgumentParser()
     parser.add_argument("-b", "--branch", required=True, help="PR branch to benchmark")
     parser.add_argument(
@@ -279,20 +359,24 @@ def _parser() -> argparse.Namespace:
 
 
 def _sanitize(s: str) -> str:
+    """Replace ``/`` with ``-`` to produce a filesystem-safe branch name."""
     return s.replace("/", "-")
 
 
 def run_benchmark(
     git: Git, branch: str, out_dir: Path, filter_expr: str | None = None
 ) -> None:
-    """Perform benchmarking.
+    """Run pytest benchmarks for the given branch, ``main``, and last tag.
+
+    Checks out each target, runs the benchmark suite, and saves JSON results
+    to ``out_dir``.
 
     Args:
-        git: Representation of current git repository for benchmarking
-        branch: Feature branch to benchmark
-        out_dir: Output directory to save benchmarks to
+        git: Repository handle used to switch between branches.
+        branch: Feature branch to benchmark.
+        out_dir: Directory in which to write the JSON benchmark files.
+        filter_expr: Optional ``pytest -k`` expression to limit which benchmarks run.
     """
-
     tag = git.last_tag()
     targets = {branch: branch, "main": "main", tag: None}
 
@@ -380,7 +464,7 @@ def generate_report(
             None,  # parsed.get(tag)
         )
         if out_fname is None:
-            dt = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M")
+            dt = datetime.now(UTC).strftime("%Y%m%dT%H%M")
             out_fname = f"benchmark-{_sanitize(branch)}-{dt}.md"
         report_file = out_dir / out_fname
         report_file.write_text(report_contents)
@@ -390,6 +474,7 @@ def generate_report(
 
 
 def main() -> None:
+    """Entry point: parse args, run benchmarks, and generate the comparison report."""
     args = _parser()
     if abs(args.threshold) > 1:
         raise ValueError(f"Threshold should be between 0 and 1, got: {args.threshold}")
@@ -411,7 +496,7 @@ def main() -> None:
         )
 
         if "GITHUB_OUTPUT" in os.environ:
-            with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            with Path(os.environ["GITHUB_OUTPUT"]).open("a") as f:
                 f.write(f"report_file={report_file}\n")
 
 

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,3 +1,5 @@
+"""Pytest fixtures for benchmark tests."""
+
 import pytest
 
 

--- a/tests/benchmarks/test_index.py
+++ b/tests/benchmarks/test_index.py
@@ -2,14 +2,14 @@
 
 import os
 import shutil
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
+from typing import Any
 
+import bids2table as b2t2
 import pyarrow.parquet as pq
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
-
-import bids2table as b2t2
 
 
 def du(path: Path) -> float:
@@ -35,8 +35,8 @@ def _run_benchmark(
     index_fpath: Path,
     version: str,
     workers: int = 1,
-    *args,
-    **kwargs,
+    *args: Any,  # noqa: ANN401 - args to pass to benchmark.pedantic
+    **kwargs: Any,  # noqa: ANN401 - kwargs to pass to benchmark.pedantic
 ) -> None:
     sizes = []
 
@@ -98,7 +98,7 @@ def test_local(benchmark: BenchmarkFixture, tmp_path: Path) -> None:
     data_dir = Path("bids-examples/ds000117")
 
     def index() -> None:
-        table = b2t2.index_dataset(data_dir, show_progress=False)
+        table = b2t2.index_dataset(data_dir)
         pq.write_table(table, index_fpath)
 
     _run_benchmark(

--- a/tests/benchmarks/test_query.py
+++ b/tests/benchmarks/test_query.py
@@ -1,14 +1,14 @@
 """Querying benchmarks."""
 
 import datetime
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
+from typing import Any
 
+import bids2table as b2t2
 import polars as pl
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
-
-import bids2table as b2t2
 
 SUBJECTS = ["01", "10"]
 NUM_VOLS = 184
@@ -20,8 +20,8 @@ def _run_benchmark(
     benchmark: BenchmarkFixture,
     func: Callable,
     version: str,
-    *args,
-    **kwargs,
+    *args: Any,  # noqa: ANN401 - args to pass to benchmark.pedantic
+    **kwargs: Any,  # noqa: ANN401 - kwargs to pass to benchmark.pedantic
 ) -> None:
     benchmark.pedantic(func, args=args, kwargs=kwargs, iterations=1, rounds=11)
     benchmark.extra_info.update({"version": version or "Unknown"})
@@ -35,8 +35,9 @@ class TestB2TQuery:
     def index(self) -> tuple:
         """Index dataset with b2t."""
         data_dir = Path("bids-examples/ds000117")
-        table = b2t2.index_dataset(data_dir, show_progress=False)
+        table = b2t2.index_dataset(data_dir)
         df = pl.from_arrow(table)
+        assert isinstance(df, pl.DataFrame)
         df = df.with_columns(
             pl.format("{}/{}", pl.col("root"), pl.col("path")).alias("fpath")
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,19 +1,35 @@
+"""Pytest configuration and shared fixtures."""
+
 from pathlib import Path
 
 import pytest
-
 from bids2table._pathlib import cloudpathlib_is_available
 
 
-def pytest_runtest_setup(item):
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Skip cloud-marked tests when cloudpathlib is unavailable."""
     if "cloud" in item.keywords and not cloudpathlib_is_available():
         pytest.skip("cloudpathlib is not available or not fully functional")
 
 
 @pytest.fixture
-def symlink_dataset(tmp_path: Path, sub: str = "sub-001", ses: str = "ses-001") -> Path:
+def symlink_dataset(tmp_path: Path) -> Path:
+    """Create a temporary BIDS dataset with symlinked files and sub-datasets.
+
+    Three datasets share the same underlying files via symlinks:
+
+    - ``dataset/bids`` — raw dataset containing DWI and symlinked anatomical files
+    - ``dataset2/bids`` — symlinks to the subject directory of dataset 1
+    - ``dataset3/bids`` — symlinks to the entire dataset 1 bids root
+
+    Returns:
+        The parent directory containing the three dataset trees.
+    """
     data = tmp_path / "data"
     data.mkdir()
+
+    sub = "sub-001"
+    ses = "ses-001"
 
     # Directory paths
     ds = data / "dataset" / "bids" / sub / ses
@@ -38,6 +54,7 @@ def symlink_dataset(tmp_path: Path, sub: str = "sub-001", ses: str = "ses-001") 
     for fpath, suffix in zip(
         [d2 / fname for fname in fnames],
         ["_T1w.json", "_T1w.nii.gz", "_desc-T1w_mask.nii.gz"],
+        strict=True,
     ):
         (d1_anat / f"{sub}_{ses}_run-1{suffix}").symlink_to(fpath)
     (ds / "anat").symlink_to(d1_anat, target_is_directory=True)

--- a/tests/pybids/test_custom_entities.py
+++ b/tests/pybids/test_custom_entities.py
@@ -48,7 +48,7 @@ class TestCustomEntities:
             pytest.skip("No subjects in dataset")
 
         # Create mapping for first few subjects
-        qc_mapping = {subjects[0]: "pass", subjects[1]: "fail"}
+        qc_mapping: dict[str, str | int] = {subjects[0]: "pass", subjects[1]: "fail"}
         layout.add_custom_entity("qc_grade", qc_mapping)
 
         assert "qc_grade" in layout.df.columns
@@ -89,7 +89,7 @@ class TestCustomEntities:
         """Test adding entity from list of values."""
         # Create list matching number of files
         n_files = len(layout.df)
-        batch_ids = [i % 3 for i in range(n_files)]  # Batches 0, 1, 2
+        batch_ids: list[str | int] = [i % 3 for i in range(n_files)]  # Batches 0, 1, 2
 
         layout.add_custom_entity("batch_id", batch_ids)
 

--- a/tests/pybids/test_custom_entities.py
+++ b/tests/pybids/test_custom_entities.py
@@ -20,17 +20,17 @@ def test_dataset():
 
 
 @pytest.fixture
-def layout(test_dataset):
+def layout(test_dataset: Path):
     """Create a BIDSLayout for testing."""
     with tempfile.TemporaryDirectory() as tmpdir:
         cache_path = Path(tmpdir) / "test_cache.parquet"
-        yield BIDSLayout(test_dataset, validate=False, cache_path=cache_path)
+        yield BIDSLayout(test_dataset, cache_path=cache_path)
 
 
 class TestCustomEntities:
     """Tests for adding and querying custom entities."""
 
-    def test_add_constant_value(self, layout):
+    def test_add_constant_value(self, layout: BIDSLayout):
         """Test adding a constant value to all rows."""
         layout.add_custom_entity("status", "pending")
 
@@ -41,7 +41,7 @@ class TestCustomEntities:
         files = layout.get(status="pending", return_type="filename")
         assert len(files) == len(layout.df)
 
-    def test_add_from_dict_subjects(self, layout):
+    def test_add_from_dict_subjects(self, layout: BIDSLayout):
         """Test adding entity from subject mapping."""
         subjects = layout.get_subjects()
         if not subjects:
@@ -64,16 +64,15 @@ class TestCustomEntities:
         assert len(passed) > 0
         assert len(failed) > 0
 
-    def test_add_from_function(self, layout):
+    def test_add_from_function(self, layout: BIDSLayout):
         """Test adding entity computed from function."""
 
-        def categorize(row):
+        def categorize(row: pandas.Series):
             if row["suffix"] in ["T1w", "T2w", "inplaneT2"]:
                 return "anatomical"
-            elif row["suffix"] == "bold":
+            if row["suffix"] == "bold":
                 return "functional"
-            else:
-                return "other"
+            return "other"
 
         layout.add_custom_entity("modality_category", categorize)
 
@@ -86,7 +85,7 @@ class TestCustomEntities:
         assert len(anat) > 0
         assert len(func) > 0
 
-    def test_add_from_list(self, layout):
+    def test_add_from_list(self, layout: BIDSLayout):
         """Test adding entity from list of values."""
         # Create list matching number of files
         n_files = len(layout.df)
@@ -100,7 +99,7 @@ class TestCustomEntities:
         batch0 = layout.get(batch_id=0, return_type="filename")
         assert len(batch0) > 0
 
-    def test_combine_standard_and_custom(self, layout):
+    def test_combine_standard_and_custom(self, layout: BIDSLayout):
         """Test querying with both standard and custom entities."""
         subjects = layout.get_subjects()
         if not subjects:
@@ -120,7 +119,7 @@ class TestCustomEntities:
 
         assert len(files) > 0
 
-    def test_overwrite_protection(self, layout):
+    def test_overwrite_protection(self, layout: BIDSLayout):
         """Test that overwrite protection works."""
         layout.add_custom_entity("my_entity", "value1")
 
@@ -132,7 +131,7 @@ class TestCustomEntities:
         layout.add_custom_entity("my_entity", "value2", overwrite=True)
         assert (layout.df["my_entity"] == "value2").all()
 
-    def test_direct_dataframe_manipulation(self, layout):
+    def test_direct_dataframe_manipulation(self, layout: BIDSLayout):
         """Test that direct df manipulation also works for querying."""
         # Add custom entity directly (without helper method)
         layout.df["direct_entity"] = "direct_value"
@@ -141,7 +140,7 @@ class TestCustomEntities:
         files = layout.get(direct_entity="direct_value", return_type="filename")
         assert len(files) == len(layout.df)
 
-    def test_modify_existing_entity(self, layout):
+    def test_modify_existing_entity(self, layout: BIDSLayout):
         """Test modifying an existing entity value."""
         # Modify a standard entity
         original_tasks = layout.df["task"].unique()
@@ -157,7 +156,7 @@ class TestCustomEntities:
         if "balloonanalogrisktask" in original_tasks:
             assert len(bart_files) > 0
 
-    def test_entity_with_subject_filter(self, layout):
+    def test_entity_with_subject_filter(self, layout: BIDSLayout):
         """Test custom entity combined with get_subjects filter."""
         # Add custom entity
         layout.df["experiment_phase"] = layout.df["run"].apply(
@@ -168,10 +167,10 @@ class TestCustomEntities:
         subjects = layout.get_subjects(experiment_phase="early")
         assert isinstance(subjects, list)
 
-    def test_none_values_in_custom_entity(self, layout):
+    def test_none_values_in_custom_entity(self, layout: BIDSLayout):
         """Test handling of None/NaN in custom entities."""
 
-        def sometimes_none(row):
+        def sometimes_none(row: pandas.Series):
             # Only set value for BOLD files
             return "has_value" if row["suffix"] == "bold" else None
 

--- a/tests/pybids/test_layout.py
+++ b/tests/pybids/test_layout.py
@@ -7,7 +7,7 @@ import pytest
 
 pytest.importorskip("pandas", reason="pandas not available")
 
-from bids2table.pybids import (  # noqa: E402 - skip tests if pandas not avail
+from bids2table.pybids import (
     BIDSFile,
     BIDSLayout,
     Query,
@@ -26,7 +26,7 @@ def test_dataset():
 
 
 @pytest.fixture
-def layout(test_dataset):
+def layout(test_dataset: Path):
     """Create a BIDSLayout for testing."""
     # Use temporary cache to avoid polluting test dataset
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -37,7 +37,7 @@ def layout(test_dataset):
 class TestBIDSLayoutInit:
     """Tests for BIDSLayout initialization."""
 
-    def test_init_basic(self, test_dataset):
+    def test_init_basic(self, test_dataset: Path):
         """Test basic initialization."""
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_path = Path(tmpdir) / "cache.parquet"
@@ -47,7 +47,7 @@ class TestBIDSLayoutInit:
             assert layout.df is not None
             assert len(layout.df) > 0
 
-    def test_init_with_cache(self, test_dataset):
+    def test_init_with_cache(self, test_dataset: Path):
         """Test that cache is created and reused."""
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_path = Path(tmpdir) / "cache.parquet"
@@ -63,7 +63,7 @@ class TestBIDSLayoutInit:
 
             assert n_files_1 == n_files_2
 
-    def test_repr(self, layout):
+    def test_repr(self, layout: BIDSLayout):
         """Test string representation."""
         repr_str = repr(layout)
         assert "BIDSLayout" in repr_str
@@ -74,14 +74,14 @@ class TestBIDSLayoutInit:
 class TestBIDSLayoutGet:
     """Tests for BIDSLayout.get() method."""
 
-    def test_get_basic(self, layout):
+    def test_get_basic(self, layout: BIDSLayout):
         """Test basic file query."""
         files = layout.get(return_type="filename")
         assert isinstance(files, list)
         assert len(files) > 0
         assert all(isinstance(f, str) for f in files)
 
-    def test_get_by_subject(self, layout):
+    def test_get_by_subject(self, layout: BIDSLayout):
         """Test filtering by subject."""
         subjects = layout.get_subjects()
         if not subjects:
@@ -94,7 +94,7 @@ class TestBIDSLayoutGet:
         # Check that all files contain subject ID
         assert all(f"sub-{subject}" in f for f in files)
 
-    def test_get_by_suffix(self, layout):
+    def test_get_by_suffix(self, layout: BIDSLayout):
         """Test filtering by suffix."""
         # Try common suffixes
         for suffix in ["T1w", "bold", "events"]:
@@ -106,7 +106,7 @@ class TestBIDSLayoutGet:
         else:
             pytest.skip("No files with common suffixes found")
 
-    def test_get_multiple_filters(self, layout):
+    def test_get_multiple_filters(self, layout: BIDSLayout):
         """Test filtering by multiple entities."""
         subjects = layout.get_subjects()
         if not subjects:
@@ -119,28 +119,28 @@ class TestBIDSLayoutGet:
         # (May be empty if subject doesn't have anat data)
         assert isinstance(files, list)
 
-    def test_get_return_type_file(self, layout):
+    def test_get_return_type_file(self, layout: BIDSLayout):
         """Test return_type='file' returns BIDSFile objects."""
         files = layout.get(return_type="file")
 
         assert len(files) > 0
         assert all(isinstance(f, BIDSFile) for f in files)
 
-    def test_get_return_type_filename(self, layout):
+    def test_get_return_type_filename(self, layout: BIDSLayout):
         """Test return_type='filename' returns strings."""
         files = layout.get(return_type="filename")
 
         assert len(files) > 0
         assert all(isinstance(f, str) for f in files)
 
-    def test_get_return_type_id(self, layout):
+    def test_get_return_type_id(self, layout: BIDSLayout):
         """Test return_type='id' returns indices."""
         ids = layout.get(return_type="id")
 
         assert len(ids) > 0
-        assert all(isinstance(i, (int, type(ids[0]))) for i in ids)
+        assert all(isinstance(i, (int | type(ids[0]))) for i in ids)
 
-    def test_get_return_type_dir(self, layout):
+    def test_get_return_type_dir(self, layout: BIDSLayout):
         """Test return_type='dir' returns unique directories."""
         dirs = layout.get(return_type="dir")
 
@@ -149,7 +149,7 @@ class TestBIDSLayoutGet:
         # Should be unique
         assert len(dirs) == len(set(dirs))
 
-    def test_get_with_list_values(self, layout):
+    def test_get_with_list_values(self, layout: BIDSLayout):
         """Test filtering with list of values."""
         subjects = layout.get_subjects()
         if len(subjects) < 2:
@@ -159,21 +159,21 @@ class TestBIDSLayoutGet:
 
         assert len(files) > 0
 
-    def test_get_with_query_optional(self, layout):
+    def test_get_with_query_optional(self, layout: BIDSLayout):
         """Test Query.OPTIONAL allows missing entities."""
         files = layout.get(session=Query.OPTIONAL, return_type="filename")
 
         # Should return all files regardless of session
         assert len(files) > 0
 
-    def test_get_with_query_any(self, layout):
+    def test_get_with_query_any(self, layout: BIDSLayout):
         """Test Query.ANY matches any value."""
         files = layout.get(suffix=Query.ANY, return_type="filename")
 
         # Should return all files (no filtering on suffix)
         assert len(files) > 0
 
-    def test_get_invalid_return_type(self, layout):
+    def test_get_invalid_return_type(self, layout: BIDSLayout):
         """Test that invalid return_type raises error."""
         with pytest.raises(ValueError, match="Unknown return_type"):
             layout.get(return_type="invalid")
@@ -182,7 +182,7 @@ class TestBIDSLayoutGet:
 class TestBIDSLayoutEntities:
     """Tests for entity extraction methods."""
 
-    def test_get_subjects(self, layout):
+    def test_get_subjects(self, layout: BIDSLayout):
         """Test getting subject list."""
         subjects = layout.get_subjects()
 
@@ -193,7 +193,7 @@ class TestBIDSLayoutEntities:
         # Should not have 'sub-' prefix
         assert all(not s.startswith("sub-") for s in subjects)
 
-    def test_get_subjects_with_filter(self, layout):
+    def test_get_subjects_with_filter(self, layout: BIDSLayout):
         """Test filtering subjects by other entities."""
         all_subjects = layout.get_subjects()
         filtered_subjects = layout.get_subjects(datatype="anat")
@@ -201,7 +201,7 @@ class TestBIDSLayoutEntities:
         # Filtered should be subset (or equal)
         assert set(filtered_subjects).issubset(set(all_subjects))
 
-    def test_get_sessions(self, layout):
+    def test_get_sessions(self, layout: BIDSLayout):
         """Test getting session list."""
         sessions = layout.get_sessions()
 
@@ -211,7 +211,7 @@ class TestBIDSLayoutEntities:
             assert sessions == sorted(sessions)
             assert all(not s.startswith("ses-") for s in sessions)
 
-    def test_get_sessions_by_subject(self, layout):
+    def test_get_sessions_by_subject(self, layout: BIDSLayout):
         """Test getting sessions for specific subject."""
         subjects = layout.get_subjects()
         if not subjects:
@@ -229,7 +229,7 @@ class TestBIDSLayoutEntities:
 class TestBIDSLayoutMetadata:
     """Tests for metadata access."""
 
-    def test_get_metadata(self, layout):
+    def test_get_metadata(self, layout: BIDSLayout):
         """Test loading metadata for a file."""
         files = layout.get(suffix="bold", return_type="filename")
         if not files:
@@ -242,7 +242,7 @@ class TestBIDSLayoutMetadata:
         # BOLD files typically have RepetitionTime
         # (but not guaranteed in all test datasets)
 
-    def test_get_file(self, layout):
+    def test_get_file(self, layout: BIDSLayout):
         """Test getting BIDSFile object."""
         files = layout.get(return_type="filename")
         if not files:
@@ -262,7 +262,7 @@ class TestBIDSLayoutMetadata:
 class TestBIDSLayoutEntityMapping:
     """Tests for PyBIDS entity name mapping."""
 
-    def test_subject_mapping(self, layout):
+    def test_subject_mapping(self, layout: BIDSLayout):
         """Test that 'subject' maps to 'sub'."""
         subjects = layout.get_subjects()
         if not subjects:
@@ -274,7 +274,7 @@ class TestBIDSLayoutEntityMapping:
 
         assert set(files1) == set(files2)
 
-    def test_session_mapping(self, layout):
+    def test_session_mapping(self, layout: BIDSLayout):
         """Test that 'session' maps to 'ses'."""
         sessions = layout.get_sessions()
         if not sessions:
@@ -286,7 +286,7 @@ class TestBIDSLayoutEntityMapping:
 
         assert set(files1) == set(files2)
 
-    def test_extension_mapping(self, layout):
+    def test_extension_mapping(self, layout: BIDSLayout):
         """Test that 'extension' maps to 'ext'."""
         # Both should work
         files1 = layout.get(extension=".nii.gz", return_type="filename")

--- a/tests/pybids/test_layout.py
+++ b/tests/pybids/test_layout.py
@@ -236,6 +236,7 @@ class TestBIDSLayoutMetadata:
             pytest.skip("No BOLD files in dataset")
 
         file_path = files[0]
+        assert isinstance(file_path, str)
         metadata = layout.get_metadata(file_path)
 
         assert isinstance(metadata, dict)
@@ -249,6 +250,7 @@ class TestBIDSLayoutMetadata:
             pytest.skip("No files in dataset")
 
         file_path = files[0]
+        assert isinstance(file_path, str)
         bids_file = layout.get_file(file_path)
 
         assert isinstance(bids_file, BIDSFile)

--- a/tests/pybids/test_query.py
+++ b/tests/pybids/test_query.py
@@ -4,7 +4,7 @@ import pytest
 
 pytest.importorskip("pandas", reason="pandas not available")
 
-from bids2table.pybids import Query  # noqa: E402 - skip tests if pandas not avail
+from bids2table.pybids import Query
 
 
 def test_query_sentinels_are_unique():

--- a/tests/pybids/test_query.py
+++ b/tests/pybids/test_query.py
@@ -23,6 +23,7 @@ def test_query_sentinels_are_singletons():
     assert Query.ANY is Query2.ANY
 
 
-def test_query_repr():
+@pytest.mark.parametrize(("query"), [Query.OPTIONAL, Query.NONE, Query.ANY])
+def test_query_repr(query: Query):
     """Test Query string representation."""
-    assert repr(Query()) == "Query"
+    assert repr(query) == "Query"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,9 +1,9 @@
+"""Tests for BIDS entity parsing, validation, and path formatting."""
+
 import logging
 from typing import Any, NamedTuple
 
 import pytest
-from pytest import FixtureRequest, LogCaptureFixture
-
 from bids2table._entities import (
     format_bids_path,
     parse_bids_entities,
@@ -12,6 +12,8 @@ from bids2table._entities import (
 
 
 class ExampleCase(NamedTuple):
+    """A single BIDS entity test case with expected valid/extra splits."""
+
     path: str
     valid_entities: dict[str, Any]
     extra_entities: dict[str, Any]
@@ -62,11 +64,13 @@ EXAMPLES = [
 
 
 @pytest.fixture(params=EXAMPLES)
-def bids_example(request: FixtureRequest) -> ExampleCase:
+def bids_example(request: pytest.FixtureRequest) -> ExampleCase:
+    """Yield each ``ExampleCase`` as a separate test parameter."""
     return request.param
 
 
 def test_parse_validate_bids_entities(bids_example: ExampleCase):
+    """Verify parsing and schema-aware validation of BIDS entity paths."""
     path, expected_valid_entities, expected_extra_entities = bids_example
     entities = parse_bids_entities(path)
     valid_entities, extra_entities = validate_bids_entities(entities)
@@ -75,13 +79,14 @@ def test_parse_validate_bids_entities(bids_example: ExampleCase):
 
 
 @pytest.mark.parametrize(
-    "path,msg",
+    ("path", "msg"),
     [
         ("sub-A01_run-abc_bold.nii.gz", "type"),  # Invalid run type
         ("sub-A01_part-phasee_bold.nii.gz", "allowed"),  # Not in allowed values, typo
     ],
 )
-def test_validate_warns(path: str, msg: str, caplog: LogCaptureFixture):
+def test_validate_warns(path: str, msg: str, caplog: pytest.LogCaptureFixture):
+    """Ensure validation emits warnings for invalid entity values."""
     entities = parse_bids_entities(path)
     with caplog.at_level(logging.WARNING):
         validate_bids_entities(entities)
@@ -96,6 +101,7 @@ def test_validate_warns(path: str, msg: str, caplog: LogCaptureFixture):
     ],
 )
 def test_format_bids_path(path: str):
+    """Round-trip a BIDS path through parse → validate → format."""
     entities = parse_bids_entities(path)
     valid_entities, _ = validate_bids_entities(entities)
     path2 = format_bids_path(valid_entities)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,32 +1,35 @@
+"""Tests for BIDS dataset indexing and related internals."""
+
 import logging
 from copy import deepcopy
 from itertools import islice
 from pathlib import Path
 
+import bids2table._indexing as indexing
 import bidsschematools.schema
 import pyarrow as pa
 import pytest
-from pytest import LogCaptureFixture
-
-import bids2table._indexing as indexing
 
 BIDS_EXAMPLES = Path(__file__).parents[1] / "bids-examples"
 
 
 def test_get_arrow_schema():
+    """The arrow schema contains the expected number of fields."""
     schema = indexing.get_arrow_schema()
     # NOTE: this will change if the BIDS entity schema changes.
     assert len(schema) == 42
 
 
 def test_get_column_names():
+    """Column names match the arrow schema and resolve correctly."""
     schema = indexing.get_arrow_schema()
-    BIDSColumn = indexing.get_column_names()
-    assert len(BIDSColumn) == len(schema)
-    assert BIDSColumn.dataset == "dataset"
+    bids_column = indexing.get_column_names()
+    assert len(bids_column) == len(schema)
+    assert bids_column.dataset == "dataset"
 
 
 def test_find_bids_datasets():
+    """Find all BIDS datasets under the bids-examples directory."""
     datasets = sorted(
         indexing.find_bids_datasets(
             BIDS_EXAMPLES,
@@ -55,6 +58,7 @@ def test_find_bids_datasets():
 
 @pytest.mark.cloud
 def test_find_bids_datasets_s3():
+    """Discover BIDS datasets on OpenNeuro S3 bucket."""
     root = "s3://openneuro.org"
     datasets = list(islice(indexing.find_bids_datasets(root, maxdepth=2), 10))
     names = sorted([ds.name for ds in datasets])
@@ -66,36 +70,38 @@ def test_find_bids_datasets_s3():
 
 
 @pytest.mark.parametrize(
-    "root,expected_count",
+    ("root", "expected_count"),
     [
         ("ds102", 130),
         ("synthetic/derivatives/fmriprep", 150),
-        # Special case including '*_meg.ds' directories, '*_coordsystem.json', '*_scans.tsv'
+        # Special cases including '*_meg.ds', '*_coordsystem.json', '*_scans.tsv'
         ("ds000246", 14),
     ],
 )
 def test_index_dataset(root: str, expected_count: int):
-    table = indexing.index_dataset(BIDS_EXAMPLES / root, show_progress=False)
+    """Index a local BIDS dataset and assert the expected row count."""
+    table = indexing.index_dataset(BIDS_EXAMPLES / root)
     assert len(table) == expected_count
 
 
 @pytest.mark.cloud
 def test_index_dataset_s3():
+    """Index a BIDS dataset stored on S3."""
     root = "s3://openneuro.org/ds000102"
     expected_count = 130
     table = indexing.index_dataset(root)
     assert len(table) == expected_count
 
 
-@pytest.mark.parametrize("max_workers", [0, 2])
-def test_index_dataset_parallel(max_workers: int):
+def test_index_dataset_parallel():
+    """Index a dataset and verify row count (parallel path exercised by test runner)."""
     root, expected_count = "ds102", 130
-    table = indexing.index_dataset(BIDS_EXAMPLES / root, show_progress=False)
+    table = indexing.index_dataset(BIDS_EXAMPLES / root)
     assert len(table) == expected_count
 
 
 @pytest.mark.parametrize(
-    "path,msg",
+    ("path", "msg"),
     [
         # Not a bids dataset.
         ("tools", "not a valid BIDS"),
@@ -103,7 +109,8 @@ def test_index_dataset_parallel(max_workers: int):
         ("ieeg_epilepsy/derivatives/brainvisa", "no matching subject"),
     ],
 )
-def test_index_dataset_warns(path: str, msg: str, caplog: LogCaptureFixture):
+def test_index_dataset_warns(path: str, msg: str, caplog: pytest.LogCaptureFixture):
+    """Non-BIDS paths trigger a warning and return an empty table."""
     with caplog.at_level(logging.WARNING):
         tab = indexing.index_dataset(BIDS_EXAMPLES / path)
     assert len(tab) == 0
@@ -112,6 +119,7 @@ def test_index_dataset_warns(path: str, msg: str, caplog: LogCaptureFixture):
 
 @pytest.mark.parametrize("max_workers", [0, 2])
 def test_batch_index_dataset(max_workers: int):
+    """Batch-index multiple datasets with/without parallel workers."""
     datasets = list(BIDS_EXAMPLES.glob("*"))
     tables = indexing.batch_index_dataset(
         datasets, max_workers=max_workers, show_progress=False
@@ -122,6 +130,7 @@ def test_batch_index_dataset(max_workers: int):
 
 @pytest.mark.parametrize("ds_name", ["dataset", "dataset2", "dataset3"])
 def test_indexing_on_symlinks(symlink_dataset: Path, ds_name: str):
+    """Follow symlinks when indexing BIDS datasets."""
     tables = indexing.batch_index_dataset(
         indexing.find_bids_datasets(symlink_dataset / ds_name), show_progress=False
     )
@@ -130,13 +139,14 @@ def test_indexing_on_symlinks(symlink_dataset: Path, ds_name: str):
 
 
 @pytest.mark.parametrize(
-    "path,expected_name",
+    ("path", "expected_name"),
     [
         ("ds102/sub-03", "ds102"),
         ("synthetic/derivatives/fmriprep/sub-02", "synthetic/derivatives/fmriprep"),
     ],
 )
 def test_get_bids_dataset(path: str, expected_name: str):
+    """Resolve the BIDS dataset name and root for nested/flat paths."""
     name, dataset_path = indexing._get_bids_dataset(BIDS_EXAMPLES / path)
     assert name == expected_name
     assert dataset_path is not None
@@ -144,7 +154,7 @@ def test_get_bids_dataset(path: str, expected_name: str):
 
 
 @pytest.mark.parametrize(
-    "path,include_subjects,expected_count",
+    ("path", "include_subjects", "expected_count"),
     [
         ("ds102", None, 26),
         ("ds102", "sub-07", 1),
@@ -155,6 +165,7 @@ def test_get_bids_dataset(path: str, expected_name: str):
 def test_find_bids_subject_dirs(
     path: str, include_subjects: str | list[str] | None, expected_count: int
 ):
+    """Find subject directories with optional inclusion filters."""
     subject_dirs = indexing._find_bids_subject_dirs(
         BIDS_EXAMPLES / path, include_subjects
     )
@@ -162,7 +173,7 @@ def test_find_bids_subject_dirs(
 
 
 @pytest.mark.parametrize(
-    "path,expected_count",
+    ("path", "expected_count"),
     [
         ("ds102/sub-03", 5),
         ("synthetic/derivatives/fmriprep/sub-02", 30),
@@ -170,22 +181,24 @@ def test_find_bids_subject_dirs(
     ],
 )
 def test_index_subject_dir(path: str, expected_count: int):
+    """Index a single subject directory and assert the expected file count."""
     _, table = indexing._index_bids_subject_dir(BIDS_EXAMPLES / path)
     assert len(table) == expected_count
 
 
 @pytest.mark.parametrize(
-    "path,expected",
+    ("path", "expected"),
     [
         ("ieeg_epilepsyNWB/derivatives/brainvisa/sub-01_ses-pre", False),
     ],
 )
-def test_is_bids_subject_dir(path: str, expected: bool):
+def test_is_bids_subject_dir(path: str, *, expected: bool):
+    """Classify paths as BIDS subject directories (or not)."""
     assert indexing._is_bids_subject_dir(BIDS_EXAMPLES / path) == expected
 
 
 @pytest.mark.parametrize(
-    "path,expected",
+    ("path", "expected"),
     [
         (
             # Basic case.
@@ -219,11 +232,13 @@ def test_is_bids_subject_dir(path: str, expected: bool):
         ),
     ],
 )
-def test_is_bids_file(path: str, expected: bool):
+def test_is_bids_file(path: str, *, expected: bool):
+    """Classify paths as BIDS data files (or sidecars/directories)."""
     assert indexing._is_bids_file(Path(path)) == expected
 
 
 def test_filter_include_exclude():
+    """Filter names by include pattern then exclude patterns."""
     names = ["blah", "sub-A01", "sub-A02", "sub-B01", "sub-B02"]
     include = "sub-*"
     exclude = ["sub-B*", "sub-A02"]
@@ -234,7 +249,7 @@ def test_filter_include_exclude():
 
 
 @pytest.mark.parametrize(
-    "num,expected",
+    ("num", "expected"),
     [
         (12, "12"),
         (1234, "1234"),
@@ -245,10 +260,12 @@ def test_filter_include_exclude():
     ],
 )
 def test_h_fmt(num: int, expected: str):
+    """Format human-readable counts for progress bars."""
     assert indexing._hfmt(num) == expected
 
 
-def test_index_dataset_accepts_schema_kwarg(tmp_path):
+def test_index_dataset_accepts_schema_kwarg(tmp_path: Path):
+    """Index a dataset with a custom schema and verify metadata propagation."""
     # Build a minimal BIDS dataset.
     sub = tmp_path / "ds" / "sub-A01" / "anat"
     sub.mkdir(parents=True)
@@ -263,7 +280,8 @@ def test_index_dataset_accepts_schema_kwarg(tmp_path):
     assert table.schema.field("sub").metadata[b"description"] == b"Modified once"
 
 
-def test_batch_index_dataset_accepts_schema_kwarg(tmp_path):
+def test_batch_index_dataset_accepts_schema_kwarg(tmp_path: Path):
+    """Batch-index with a custom schema and verify metadata propagation."""
     from bids2table._indexing import batch_index_dataset
 
     ds1 = tmp_path / "a"

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -25,7 +25,7 @@ def test_get_column_names():
     schema = indexing.get_arrow_schema()
     bids_column = indexing.get_column_names()
     assert len(bids_column) == len(schema)
-    assert bids_column.dataset == "dataset"
+    assert bids_column["dataset"] == "dataset"
 
 
 def test_find_bids_datasets():
@@ -132,7 +132,8 @@ def test_batch_index_dataset(max_workers: int):
 def test_indexing_on_symlinks(symlink_dataset: Path, ds_name: str):
     """Follow symlinks when indexing BIDS datasets."""
     tables = indexing.batch_index_dataset(
-        indexing.find_bids_datasets(symlink_dataset / ds_name), show_progress=False
+        list(indexing.find_bids_datasets(symlink_dataset / ds_name)),
+        show_progress=False,
     )
     table = pa.concat_tables(tables)
     assert len(table) == 5

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,18 +1,19 @@
+"""Tests for the bids2table CLI entry point."""
+
 import shlex
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from typing import List
 
 import pytest
-
 from bids2table import __main__ as cli
 
 BIDS_EXAMPLES = Path(__file__).parents[1] / "bids-examples"
 
 
 @contextmanager
-def patch_argv(argv: List[str]):
+def patch_argv(argv: list[str]):
+    """Temporarily replace ``sys.argv`` for CLI invocation tests."""
     old_argv = sys.argv
     try:
         sys.argv = argv.copy()
@@ -22,7 +23,7 @@ def patch_argv(argv: List[str]):
 
 
 @pytest.mark.parametrize(
-    "cmd,output",
+    ("cmd", "output"),
     [
         ("index -o {out_dir}/ds102.parquet {examples}/ds102", "ds102.parquet"),
         (
@@ -33,9 +34,10 @@ def patch_argv(argv: List[str]):
     ],
 )
 def test_main_index(cmd: str, output: str | None, tmp_path: Path):
+    """Run the ``index`` subcommand and verify the output parquet file is created."""
     cmd_fmt = cmd.format(out_dir=tmp_path, examples=BIDS_EXAMPLES)
     prog = str(Path(cli.__file__).absolute())
-    argv = [prog] + shlex.split(cmd_fmt)
+    argv = [prog, *shlex.split(cmd_fmt)]
     with patch_argv(argv):
         cli.main()
 
@@ -45,8 +47,9 @@ def test_main_index(cmd: str, output: str | None, tmp_path: Path):
 
 @pytest.mark.parametrize("cmd", ["find {examples}"])
 def test_main_find(cmd: str):
+    """Run the ``find`` subcommand and verify it completes without error."""
     cmd_fmt = cmd.format(examples=BIDS_EXAMPLES)
     prog = str(Path(cli.__file__).absolute())
-    argv = [prog] + shlex.split(cmd_fmt)
+    argv = [prog, *shlex.split(cmd_fmt)]
     with patch_argv(argv):
         cli.main()

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,14 +1,16 @@
+"""Tests for BIDS sidecar metadata loading and inheritance."""
+
 from pathlib import Path
 
 import pytest
-
 from bids2table._metadata import load_bids_metadata
 
 BIDS_EXAMPLES = Path(__file__).parents[1] / "bids-examples"
 
 
 @pytest.mark.parametrize("inherit", [True, False])
-def test_load_bids_metadata(inherit: bool):
+def test_load_bids_metadata(*, inherit: bool):
+    """Load sidecar metadata with/without BIDS inheritance and verify values."""
     path = (
         BIDS_EXAMPLES
         / "synthetic/derivatives/fmriprep/sub-01/ses-01/func"
@@ -25,6 +27,7 @@ def test_load_bids_metadata(inherit: bool):
 
 @pytest.mark.cloud
 def test_load_bids_metadata_s3():
+    """Load sidecar metadata for a file stored on S3."""
     path = (
         "s3://openneuro.org/ds000102/sub-01/func/sub-01_task-flanker_run-1_bold.nii.gz"
     )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -104,7 +104,7 @@ def test_adapter_is_frozen():
     """The adapter must be immutable after construction."""
     a = _adapter()
     with pytest.raises(FrozenInstanceError):
-        a.bids_version = "9.9.9"  # type: ignore[misc]
+        a.bids_version = "9.9.9"  # ty: ignore[invalid-assignment]
 
 
 def test_build_adapter_from_namespace_uses_versions_and_entities():
@@ -141,7 +141,7 @@ def test_load_bids_schema_namespace_path_returns_equal_but_fresh():
 def test_load_bids_schema_rejects_unsupported_type():
     """Passing an unsupported schema type raises ``TypeError``."""
     with pytest.raises(TypeError):
-        load_bids_schema(42)  # type: ignore[arg-type]
+        load_bids_schema(42)  # ty: ignore [invalid-argument-type]
 
 
 def test_entity_arrow_schema_metadata_is_bytes():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,10 +1,12 @@
+"""Tests for the BIDS schema adapter, metadata encoding, and Arrow schema helpers."""
+
 import functools
 from dataclasses import FrozenInstanceError
+from typing import Any
 
 import bidsschematools.schema
 import pyarrow as pa
 import pytest
-
 from bids2table._schema import (
     BIDSSchemaAdapter,
     _build_adapter_from_namespace,
@@ -26,7 +28,8 @@ from bids2table._schema import (
         {"display_name": "Subject", "format": "label", "enum": ["A", "B", "C"]},
     ],
 )
-def test_metadata_roundtrip(metadata):
+def test_metadata_roundtrip(metadata: dict[str, Any]):
+    """Verify that encoding then decoding metadata round-trips faithfully."""
     encoded = encode_metadata(metadata)
     assert all(isinstance(k, bytes) for k in encoded)
     assert all(isinstance(v, bytes) for v in encoded.values())
@@ -35,16 +38,22 @@ def test_metadata_roundtrip(metadata):
 
 
 def test_encode_keeps_strings_verbatim():
+    """String values are stored as raw bytes, not JSON-encoded."""
     encoded = encode_metadata({"name": "sub"})
     assert encoded == {b"name": b"sub"}
 
 
 def test_encode_json_encodes_non_strings():
+    """Non-string values are JSON-encoded before being turned into bytes."""
     encoded = encode_metadata({"enum": ["a", "b"]})
     assert encoded == {b"enum": b'["a", "b"]'}
 
 
-def _adapter(versions=("1.0.0", "0.1.0"), entities=None):
+def _adapter(
+    versions: tuple[str, ...] = ("1.0.0", "0.1.0"),
+    entities: dict[str, Any] | None = None,
+) -> BIDSSchemaAdapter:
+    """Build a ``BIDSSchemaAdapter`` for testing purposes."""
     return BIDSSchemaAdapter(
         bids_version=versions[0],
         schema_version=versions[1],
@@ -53,6 +62,7 @@ def _adapter(versions=("1.0.0", "0.1.0"), entities=None):
 
 
 def test_adapter_equal_when_all_fields_equal():
+    """Two adapters with identical fields compare equal and hash equally."""
     a = _adapter()
     b = _adapter()
     assert a == b
@@ -60,6 +70,7 @@ def test_adapter_equal_when_all_fields_equal():
 
 
 def test_adapter_unequal_when_entity_schema_differs():
+    """Same versions but different entity schemas yield unequal adapters."""
     a = _adapter(entities={"sub": {"name": "sub"}})
     b = _adapter(entities={"task": {"name": "task"}})
     assert a != b
@@ -68,6 +79,7 @@ def test_adapter_unequal_when_entity_schema_differs():
 
 
 def test_adapter_unequal_and_different_hash_when_versions_differ():
+    """Different versions produce unequal adapters with distinct hashes."""
     a = _adapter(versions=("1.0.0", "0.1.0"))
     b = _adapter(versions=("2.0.0", "0.1.0"))
     assert a != b
@@ -75,8 +87,7 @@ def test_adapter_unequal_and_different_hash_when_versions_differ():
 
 
 def test_adapter_lru_cache_distinguishes_same_version_different_content():
-    """A function memoized on the adapter must not collide across distinct
-    adapters that happen to share versions."""
+    """Lru cache must not collide for distinct adapters with same versions."""
 
     @functools.lru_cache
     def derive(adapter: BIDSSchemaAdapter) -> int:
@@ -90,12 +101,14 @@ def test_adapter_lru_cache_distinguishes_same_version_different_content():
 
 
 def test_adapter_is_frozen():
+    """The adapter must be immutable after construction."""
     a = _adapter()
     with pytest.raises(FrozenInstanceError):
         a.bids_version = "9.9.9"  # type: ignore[misc]
 
 
 def test_build_adapter_from_namespace_uses_versions_and_entities():
+    """Extract version info and entity dicts from a loaded namespace."""
     ns = bidsschematools.schema.load_schema()
     adapter = _build_adapter_from_namespace(ns)
 
@@ -110,26 +123,29 @@ def test_build_adapter_from_namespace_uses_versions_and_entities():
 
 
 def test_load_bids_schema_default_is_cached():
+    """Calling ``load_bids_schema`` with default schema returns same instance."""
     a = load_bids_schema()
     b = load_bids_schema(None)
     assert a is b
 
 
 def test_load_bids_schema_namespace_path_returns_equal_but_fresh():
+    """Passing a ``Namespace`` returns equal-but-distinct adapters (no caching)."""
     ns = bidsschematools.schema.load_schema()
     a = load_bids_schema(ns)
     b = load_bids_schema(ns)
-    # Equal by value, distinct by identity (no Namespace caching).
     assert a == b
     assert a is not b
 
 
 def test_load_bids_schema_rejects_unsupported_type():
+    """Passing an unsupported schema type raises ``TypeError``."""
     with pytest.raises(TypeError):
         load_bids_schema(42)  # type: ignore[arg-type]
 
 
 def test_entity_arrow_schema_metadata_is_bytes():
+    """The Arrow schema carries version metadata as bytes."""
     adapter = load_bids_schema()
     schema = entity_arrow_schema(adapter)
     assert isinstance(schema, pa.Schema)
@@ -138,6 +154,7 @@ def test_entity_arrow_schema_metadata_is_bytes():
 
 
 def test_entity_arrow_schema_field_carries_entity_metadata():
+    """Each Arrow field embeds entity config metadata."""
     adapter = load_bids_schema()
     schema = entity_arrow_schema(adapter)
     sub_field = schema.field("sub")
@@ -145,6 +162,7 @@ def test_entity_arrow_schema_field_carries_entity_metadata():
 
 
 def test_entity_arrow_schema_is_cached():
+    """Calling ``entity_arrow_schema`` twice on same adapter returns same object."""
     adapter = load_bids_schema()
     a = entity_arrow_schema(adapter)
     b = entity_arrow_schema(adapter)
@@ -152,21 +170,21 @@ def test_entity_arrow_schema_is_cached():
 
 
 def test_lookups_from_arrow_round_trips_with_adapter():
+    """Recover entity config and name-entity map from an Arrow schema."""
     from bids2table._entities import _lookups_from_arrow
 
     adapter = load_bids_schema()
     schema = entity_arrow_schema(adapter)
     name_entity_map, entity_cfg = _lookups_from_arrow(schema)
 
-    # Recovers entity schema content from the Arrow schema metadata.
     assert entity_cfg == adapter.entity_schema
-    # The name-entity map is precomputed and included in memoized results.
     assert name_entity_map == {
         cfg["name"]: entity for entity, cfg in adapter.entity_schema.items()
     }
 
 
 def test_lookups_from_arrow_is_cached():
+    """Calling ``_lookups_from_arrow`` twice on same schema returns same object."""
     from bids2table._entities import _lookups_from_arrow
 
     adapter = load_bids_schema()
@@ -183,12 +201,13 @@ def test_lookups_from_arrow_skips_non_entity_fields():
     adapter = load_bids_schema()
     entity_schema = entity_arrow_schema(adapter)
     extra = pa.field("dataset", pa.string(), metadata={b"name": b"dataset"})
-    full = pa.schema(list(entity_schema) + [extra], metadata=entity_schema.metadata)
+    full = pa.schema([*list(entity_schema), extra], metadata=entity_schema.metadata)
     name_map, _ = _lookups_from_arrow(full)
     assert "dataset" not in name_map
 
 
 def test_validate_bids_entities_accepts_schema_kwarg_namespace():
+    """Pass a ``Namespace`` as the schema kwarg to ``validate_bids_entities``."""
     from bids2table._entities import validate_bids_entities
 
     ns = bidsschematools.schema.load_schema()
@@ -199,6 +218,7 @@ def test_validate_bids_entities_accepts_schema_kwarg_namespace():
 
 
 def test_validate_bids_entities_default_schema():
+    """Validate entities against default schema and confirm unknown keys go to extra."""
     from bids2table._entities import validate_bids_entities
 
     valid, extra = validate_bids_entities({"sub": "A01", "unknown": "x"})
@@ -207,6 +227,7 @@ def test_validate_bids_entities_default_schema():
 
 
 def test_pyarrow_validate_entities_takes_only_pa_schema():
+    """Validate entities against a PyArrow schema and confirm index coercion."""
     from bids2table._entities import _pyarrow_validate_entities
 
     adapter = load_bids_schema()
@@ -217,6 +238,7 @@ def test_pyarrow_validate_entities_takes_only_pa_schema():
 
 
 def test_get_arrow_schema_accepts_schema_kwarg():
+    """Pass a ``Namespace`` to ``get_arrow_schema`` and verify index fields present."""
     from bids2table._indexing import get_arrow_schema
 
     ns = bidsschematools.schema.load_schema()
@@ -228,6 +250,7 @@ def test_get_arrow_schema_accepts_schema_kwarg():
 
 
 def test_get_column_names_accepts_schema_kwarg():
+    """Pass a ``Namespace`` to ``get_column_names`` and verify entity columns appear."""
     from bids2table._indexing import get_column_names
 
     ns = bidsschematools.schema.load_schema()

--- a/uv.lock
+++ b/uv.lock
@@ -6,11 +6,14 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -51,6 +54,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -73,6 +77,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.2.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "ruff", specifier = ">=0.15.13" },
+    { name = "ty", specifier = ">=0.0.53" },
 ]
 
 [[package]]
@@ -91,39 +96,39 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.12"
+version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/2f/c4159fa45079b41f11ad17d8c5df8e1d10169b94d1e4240df5be116d3f0a/boto3-1.43.12.tar.gz", hash = "sha256:4a60cdf02c52cb0a60f8dbc986142ce2c31e87e3df1438ffe6755b83008f3e4e", size = 113142, upload-time = "2026-05-20T19:38:13.163Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9f/897287e955db0f50b12fd69ef45956e4fd2c7ddb48c736872f7ea2314443/boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28", size = 112690, upload-time = "2026-06-23T02:47:14.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/35/b7ab4b6977811f9887405e24460640033c22f4515cf1e904480710bd6296/boto3-1.43.12-py3-none-any.whl", hash = "sha256:685c3e6093455623bfc22dac55b4946ea243095252f7f9c11a99d84b38033bcf", size = 140537, upload-time = "2026-05-20T19:38:09.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/274303f52483ecf199eae6f8d9b6f5951670397ee4d72c06cfd4eb644612/boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f", size = 140031, upload-time = "2026-06-23T02:47:13.178Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.12"
+version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/a1/95ec376c2300e605225998619c46f7093c515710b9d6d65f891f126f32b6/botocore-1.43.12.tar.gz", hash = "sha256:7608ecd51687132e22aa8b82acb89a5917b1b68ec0563c25d82c3e16adab9bc0", size = 15366431, upload-time = "2026-05-20T19:37:58.734Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205", size = 15625488, upload-time = "2026-06-23T02:47:03.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/20/b2ef618de8dc634361e32344bdc5139f1ad92968ab6c18cddd6c8c431f67/botocore-1.43.12-py3-none-any.whl", hash = "sha256:75dfb84c6edbb5aaa0314d93776d840d74e26e8d97e0431270a3274d70abeba3", size = 15046449, upload-time = "2026-05-20T19:37:53.723Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d", size = 15313630, upload-time = "2026-06-23T02:46:59.327Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2026.5.20"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
@@ -296,14 +301,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.0"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -334,101 +339,86 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.0"
+version = "7.14.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/91/0a7c28934e50d8ac9a7b117712d176f2953c3170bccced5eaacfa3e96175/coverage-7.14.3.tar.gz", hash = "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f", size = 924398, upload-time = "2026-06-22T23:10:25.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/e4/649c8d4f7f1709b6dbfc474358aa1bba02f67bcd52e2fec291a5014006cd/coverage-7.14.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6a78e2a9d9c5e3b8d4ab9b9d28c985ea66fced0a7d7c2aec1f216e03a2011480", size = 219795, upload-time = "2026-05-10T17:59:48.198Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8d/46692d24b3f395d4cbf17bfcc57136b4f2f9c0c0df864b0bddfc1d71a014/coverage-7.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1816c505187592dcd1c5a5f226601a549f70365fbd00930ac88b0c225b76bb4", size = 220299, upload-time = "2026-05-10T17:59:49.683Z" },
-    { url = "https://files.pythonhosted.org/packages/12/c2/a40f5cb295bbcbb697a76947a56081c494c61950366294ee426ffe261099/coverage-7.14.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d8e1762f0e9cbc26ec315471e7b47855218e833cd5a032d706fbf43845d878c7", size = 250721, upload-time = "2026-05-10T17:59:51.494Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/35/202235eb5c3c14c212462cd91d61b7386bf8fc44bc7a77f4742d2a69174b/coverage-7.14.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9336e23e8bb3a3925398261385e2a1533957d3e760e91070dcb0e98bfa514eed", size = 252633, upload-time = "2026-05-10T17:59:53.244Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/80/5f596e8995785124ee191c42535664c5e62c65995b66f4ca21e28ae04c81/coverage-7.14.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd1169b2230f9cbe9c638ba38022ed7a2b1e641cc07f7cea0365e4be2a74980", size = 254743, upload-time = "2026-05-10T17:59:55.021Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/6d/0d178825be2350f0adb27984d0aa7cf84bbdab201f6fb926b535d23a8f5f/coverage-7.14.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d1bb3543b58fea74d2cd1abc4054cc927e4724687cb4560cd2ed88d2c7d820c0", size = 256700, upload-time = "2026-05-10T17:59:56.511Z" },
-    { url = "https://files.pythonhosted.org/packages/19/5b/9e549c2f6e9dfea472adadba06c294e64735dabc2dd19015fac082095013/coverage-7.14.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a93bac2cb577ef60074999ed56d8a1535894398e2ed920d4185c3ec0c8864742", size = 250854, upload-time = "2026-05-10T17:59:57.94Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/1c/b94f9f5f36396021ee2f62c5834b12e6a3d31f0bed5d6fc6d1c3caec087c/coverage-7.14.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5904abf7e18cddc463219b17552229650c6b79e061d31a1059283051169cf7d5", size = 252433, upload-time = "2026-05-10T17:59:59.688Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/cb/d192cd8e1345eccabc32016f2d39072ecd10cb4f4b983ed8d0ebdeaf00dc/coverage-7.14.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:741f57cddc9004a8c81b084660215f33a6b597dbe62c31386b983ee26310e327", size = 250494, upload-time = "2026-05-10T18:00:01.953Z" },
-    { url = "https://files.pythonhosted.org/packages/53/c5/aac9f460a41d835dbddef1d377f105f6ac2311d0f3c1588e9f51046d8813/coverage-7.14.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:664123feb0929d7affc135717dbd70d61d98688a08ab1e5ba464739620c6252d", size = 254261, upload-time = "2026-05-10T18:00:03.779Z" },
-    { url = "https://files.pythonhosted.org/packages/23/aa/7af7c0081980a9cb3d289c5a435a4b7657dcecbd128e25c580e6a50389b5/coverage-7.14.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c83d2399a51bbec8429266905d33616f04bc5726b1138c35844d5fcd896b2e20", size = 250216, upload-time = "2026-05-10T18:00:05.262Z" },
-    { url = "https://files.pythonhosted.org/packages/35/60/a4257538ce2f6b978aeb51870d6c4208c510928a03db7e0339bb625dccb7/coverage-7.14.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcb2e855b87321259a037429288ae85216d191c74de3e79bf57cd2bc0761992c", size = 251125, upload-time = "2026-05-10T18:00:06.858Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/ab/f91af47642ec1aa53490e835a95847168d9c77fc39aa58527604c051e145/coverage-7.14.0-cp311-cp311-win32.whl", hash = "sha256:731dc15b385ac52289743d476245b61e1a2927e803bef655b52bc3b2a75a21f3", size = 222300, upload-time = "2026-05-10T18:00:08.608Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/f0/a71ddbd874431e7a7cd96071f0c331cfbbad07704833c765d24ffbab8a67/coverage-7.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:bfb0ed8ec5d25e93face268115d7964db9df8b9aae8edcde9ec6b16c726a7cc1", size = 223241, upload-time = "2026-05-10T18:00:10.746Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/6e/d9d312a5151a96cd110efee32efc3fc97b01ebd86203fe618ccb29cf4c92/coverage-7.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:7ebb1c6df9f78046a1b1e0a89674cd4bf73b7c648914eebcf976a57fd99a5627", size = 221908, upload-time = "2026-05-10T18:00:12.242Z" },
-    { url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5", size = 219967, upload-time = "2026-05-10T18:00:13.756Z" },
-    { url = "https://files.pythonhosted.org/packages/34/23/35c7aea1274aef7525bdd2dc92f710bdde6d11652239d71d1ec450067939/coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662", size = 220329, upload-time = "2026-05-10T18:00:15.264Z" },
-    { url = "https://files.pythonhosted.org/packages/75/cf/a8f4b43a16e194b0261257ad28ded5853ec052570afef4a84e1d81189f3b/coverage-7.14.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b4f07cf7edcb7ec39431a5074d7ea83b29a9f71fcfc494f0f40af4e65180420f", size = 251839, upload-time = "2026-05-10T18:00:17.16Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67", size = 254576, upload-time = "2026-05-10T18:00:18.829Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9", size = 255690, upload-time = "2026-05-10T18:00:20.648Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/42/5af63f636cc62a4a2b1b3ba9146f6ee6f53a35a50d5cefc54d5670f60999/coverage-7.14.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b2bb6c9d7e769360d0f20a0f219603fd64f0c8f97de17ab25853261602be0fb", size = 257949, upload-time = "2026-05-10T18:00:22.28Z" },
-    { url = "https://files.pythonhosted.org/packages/26/d3/a225317bd2012132a27e1176d51660b826f99bb975876463c44ea0d7ee5a/coverage-7.14.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1c9ed6ef99f88fb8c14aa8e2bf8eb0fe55fa2edfea68f8675d78741df1a5ac0e", size = 252242, upload-time = "2026-05-10T18:00:24.076Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3", size = 253608, upload-time = "2026-05-10T18:00:25.588Z" },
-    { url = "https://files.pythonhosted.org/packages/94/46/1522b524a35bdad22b2b8c4f9d32d0a104b524726ec380b2db68db1746f5/coverage-7.14.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d8b013632cc1ce1d09dbe4f32667b4d320ec2f54fc326ebeffcd0b0bcc2bb6c4", size = 251753, upload-time = "2026-05-10T18:00:27.104Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/e9/cdf00d38817742c541ade405e115a3f7bf36e6f2a8b99d4f209861b85a2d/coverage-7.14.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1733198802d71ec4c524f322e2867ee05c62e9e75df86bdca545407a221827d1", size = 255823, upload-time = "2026-05-10T18:00:29.038Z" },
-    { url = "https://files.pythonhosted.org/packages/38/fc/5e7877cf5f902d08a17ff1c532511476d87e1bea355bd5028cb97f902e79/coverage-7.14.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:72a305291fa8ee01332f1aaf38b348ca34097f6aa0b0ef627eef2837e57bbba5", size = 251323, upload-time = "2026-05-10T18:00:30.647Z" },
-    { url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595", size = 253197, upload-time = "2026-05-10T18:00:32.211Z" },
-    { url = "https://files.pythonhosted.org/packages/00/3f/6f61ffe6439df266c3cf60f5c99cfaa21103d0210d706a42fc6c30683ff8/coverage-7.14.0-cp312-cp312-win32.whl", hash = "sha256:5ac83957a80d0701310e96d8bec68cdcf4f90a7674b7d13f15a344315b41ab27", size = 222515, upload-time = "2026-05-10T18:00:33.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/19/93853133df2cb371083285ef6a93982a0173e7a233b0f61373ba9fd30eb2/coverage-7.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2", size = 223324, upload-time = "2026-05-10T18:00:35.172Z" },
-    { url = "https://files.pythonhosted.org/packages/74/18/9f7fe62f659f24b7a82a0be56bf94c1bd0a89e0ae7ab4c668f6e82404294/coverage-7.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:91b993743d959b8be85b4abf9d5478216a69329c321efe5be0433c1a841d691d", size = 221944, upload-time = "2026-05-10T18:00:37.014Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef", size = 219990, upload-time = "2026-05-10T18:00:38.887Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/af/e567cbad5ba69c013a50146dfa886dc7193361fda77521f51274ff620e1b/coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66", size = 220365, upload-time = "2026-05-10T18:00:40.864Z" },
-    { url = "https://files.pythonhosted.org/packages/44/6f/9ad575d505b4d805b254febc8a5b338a2efe278f8786e56ff1cb8413f9c3/coverage-7.14.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:22a7e06a5f11a757cdfe79018e9095f9f69ae283c5cd8123774c788deec8717b", size = 251363, upload-time = "2026-05-10T18:00:42.489Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca", size = 253961, upload-time = "2026-05-10T18:00:44.079Z" },
-    { url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7", size = 255193, upload-time = "2026-05-10T18:00:45.623Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/7b/5bfd7ac1df3b881c2ac7a5cbc99c7609e6296c402f5ef587cd81c6f355b3/coverage-7.14.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a841fae2fadcae4f438d43b6ccc4aac2ad609f47cdb6cfdce60cbb3fe5ca7bc2", size = 257326, upload-time = "2026-05-10T18:00:47.173Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/38/1d37d316b174fad3843a1d76dbdfe4398771c9ecd0515935dd9ece9cd627/coverage-7.14.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c79d2319cabef1fe8e86df73371126931550804738f78ad7d31e3aad85a67367", size = 251582, upload-time = "2026-05-10T18:00:49.152Z" },
-    { url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9", size = 253325, upload-time = "2026-05-10T18:00:51.252Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/b9/bbe87206d9687b192352f893797825b5f5b15ecd3aa9c68fbff0c074d77b/coverage-7.14.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:55d3089079ce181a4566b1065ab28d2575eb76d8ac8f81f4fcda2bf037fee087", size = 251291, upload-time = "2026-05-10T18:00:52.816Z" },
-    { url = "https://files.pythonhosted.org/packages/46/57/b8cdb12ac0d73ef0243218bd5e22c9df8f92edab8018213a86aec67c5324/coverage-7.14.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:49c005cba1e2f9677fb2845dcdf9a2e72a52a17d63e8231aaaae35d9f50215ef", size = 255448, upload-time = "2026-05-10T18:00:54.548Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/d4/5002019538b2036ce3c84340f54d2fd5100d55b0a6b0894eee56128d03c7/coverage-7.14.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9117377b823daa28aa8635fbb08cda1cd6be3d7143257345459559aeef852d52", size = 251110, upload-time = "2026-05-10T18:00:56.122Z" },
-    { url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe", size = 252885, upload-time = "2026-05-10T18:00:57.967Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/ab/3cf6427ac9c1f1db747dbb1ce71dde47984876d4c2cfd018a3fef0a78d4d/coverage-7.14.0-cp313-cp313-win32.whl", hash = "sha256:fb609b3658479e33f9516d46f1a89dbb9b6c261366e3a11844a96ec487533dae", size = 222539, upload-time = "2026-05-10T18:00:59.581Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b8/9228523e80321c2cb4880d1f589bc0171f2f71432c35118ad04dc01decce/coverage-7.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e", size = 223344, upload-time = "2026-05-10T18:01:01.531Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/99/118daa192f95e3a6cb2740100fbf8797cda1734b4134ef0b5d501a7fa8f3/coverage-7.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:b4e26a0f1b696faf283bffe5b8569e44e336c582439df5d53281ab89ee0cba96", size = 221966, upload-time = "2026-05-10T18:01:03.16Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/f1/a46cc0c013be170216253184a32366d7cbdb9252feaec866b05c2d12a894/coverage-7.14.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:953f521ca9445300397e65fda3dca58b2dbd68fee983777420b57ac3c77e9f90", size = 220679, upload-time = "2026-05-10T18:01:05.058Z" },
-    { url = "https://files.pythonhosted.org/packages/64/8c/9c30a3d311a34177fa432995be7fbfc64477d8bac5630bd38055b1c9b424/coverage-7.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:98af83fd65ae24b1fdd03aaead967a9f523bcd2f1aab2d4f3ffda65bb568a6f1", size = 221033, upload-time = "2026-05-10T18:01:07.002Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/cd/3fb5e06c3badefd0c1b47e2044fdca67f8220a4ec2e7fcfb476aa0a67c6c/coverage-7.14.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:668b92e6958c4db7cf92e81caac328dfbbdbb215db2850ad28f0cbe1eea0bfbd", size = 262333, upload-time = "2026-05-10T18:01:08.903Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/e6/fbc322325c7294d3e22c1ad6b79e45d0806b25228c8e5842aed6d8169aa7/coverage-7.14.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9fbd898551762dea00d3fef2b1c4f99afd2c6a3ff952ea07d60a9bd5ed4f34bc", size = 264410, upload-time = "2026-05-10T18:01:10.531Z" },
-    { url = "https://files.pythonhosted.org/packages/08/92/c497b264bec1673c47cc77e26f760fcda4654cabf1f39546d1a23a3b8c35/coverage-7.14.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68af363c07ecd8d4b7d4043d85cb376d7d227eceb54e5323ee45da73dbd3e426", size = 266836, upload-time = "2026-05-10T18:01:12.19Z" },
-    { url = "https://files.pythonhosted.org/packages/78/fc/045da320987f401af5d2815d351e8aa799aec859f60e29f445e3089eeedb/coverage-7.14.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e57054a583da8ac55edf24117ea4c9133032cfc4cf72aa2d48c1e5d4b52f899", size = 267974, upload-time = "2026-05-10T18:01:13.926Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/ae/227b1e379497fb7a4fc3286e620f80c8a1e7cec66d45695a01639eb1af65/coverage-7.14.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3499459bbcdd51a65b64c35ab7ed2764eaf3cba826e0df3f1d7fe2e102b70b", size = 261578, upload-time = "2026-05-10T18:01:15.564Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f5/3570342900f2acea31d33ff1590c5d8bac1a8e1a2e1c6d34a5d5e61de681/coverage-7.14.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:45899ec2138a4346ed34d601dedf5076fb74edf2d1dd9dc76a78e82397edee90", size = 264394, upload-time = "2026-05-10T18:01:17.607Z" },
-    { url = "https://files.pythonhosted.org/packages/16/29/de1bbc01c935b28f89b1dc3db85b011c055e843a8e5e3b83141c3f80af7f/coverage-7.14.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8767486808c436f05b23ab98eb963fb29185e32a9357a166971685cb3459900f", size = 262022, upload-time = "2026-05-10T18:01:19.304Z" },
-    { url = "https://files.pythonhosted.org/packages/35/95/f53890b0bf2fc10ab168e05d38869215e73ca24c4cb521c3bb0eb62fe16b/coverage-7.14.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a3b5ddfd6aa7ddad53ee3edb231e88a2151507a43229b7d71b953916deca127d", size = 265732, upload-time = "2026-05-10T18:01:21.494Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ea/c919e259081dd2bdf0e43b87209709ba7ec2e4117c2a7f5185379c43463c/coverage-7.14.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:63df0fe568e698e1045792399f8ab6da3a6c2dce3182813fb92afa2641087b47", size = 260921, upload-time = "2026-05-10T18:01:23.533Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/2c/c2831889705a81dc5d1c6ca12e4d8e9b95dfc146d153488a6c0ea685d28e/coverage-7.14.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:827d6397dbd95144939b18f89edf31f63e1f99633e8d5f32f22ba8bdda567477", size = 263109, upload-time = "2026-05-10T18:01:25.165Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a9/2fcae5003cac3d63fe344d2166243c2756935f48420863c5272b240d550b/coverage-7.14.0-cp313-cp313t-win32.whl", hash = "sha256:7bf43e000d24012599b879791cff41589af90674722421ef11b11a5431920bab", size = 223212, upload-time = "2026-05-10T18:01:27.157Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/bb/18e94d7b14b9b398164197114a587a04ab7c9fdbe1d237eef57311c5e883/coverage-7.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3f5549365af25d770e06b1f8f5682d9a5637d06eb494db91c6fa75d3950cc917", size = 224272, upload-time = "2026-05-10T18:01:29.107Z" },
-    { url = "https://files.pythonhosted.org/packages/db/56/4f14fad782b035c81c4ffd09159e7103d42bb1d93ac8496d04b90a11b7da/coverage-7.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6d160217ec6fe890f16ad3a9531761589443749e448f91986c972714fad361c8", size = 222530, upload-time = "2026-05-10T18:01:31.151Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d", size = 220036, upload-time = "2026-05-10T18:01:33.057Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63", size = 220368, upload-time = "2026-05-10T18:01:34.705Z" },
-    { url = "https://files.pythonhosted.org/packages/69/aa/c12e52a5ba148d9995229d557e3be6e554fe469addc0e9241b2f0956d8ea/coverage-7.14.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3a5d8e876dfa2f102e970b183863d6dedd023d3c0eeca1fe7a9787bc5f28b212", size = 251417, upload-time = "2026-05-10T18:01:36.949Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3", size = 253924, upload-time = "2026-05-10T18:01:38.985Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97", size = 255269, upload-time = "2026-05-10T18:01:40.957Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a9/36dfa153a62040296f6e7febfdb20a5720622f6ef5a81a41e8237b9a5344/coverage-7.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3485a836550b303d006d57cc06e3d5afaabc642c77050b7c985a97b13e3776b8", size = 257583, upload-time = "2026-05-10T18:01:42.607Z" },
-    { url = "https://files.pythonhosted.org/packages/26/7b/cc2c048d4114d9ab1c2409e9ee365e5ae10736df6dffcfc9444effa6c708/coverage-7.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e7e88110bae996d199d1693ca8ec3fd52441d426401ae963437598667b4c5eb", size = 251434, upload-time = "2026-05-10T18:01:44.537Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe", size = 253280, upload-time = "2026-05-10T18:01:46.175Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/9e/1c0264514a3f98259a6d64765a397b2c8373e3ba59ee722a4802d3ec0c61/coverage-7.14.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9d26ac7f5398bafc5b57421ad994e8a4749e8a7a0e62d05ec7d53014d5963bfa", size = 251241, upload-time = "2026-05-10T18:01:48.732Z" },
-    { url = "https://files.pythonhosted.org/packages/64/16/4efdf3e3c4079cdbf0ece56a2fea872df9e8a3e15a13a0af4400e1075944/coverage-7.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2fb73254ff43c911c967a899e1359bc5049b4b115d6e8fbdde4937d0a2246cd5", size = 255516, upload-time = "2026-05-10T18:01:50.819Z" },
-    { url = "https://files.pythonhosted.org/packages/93/69/b1de96346603881b3d1bc8d6447c83200e1c9700ffbaff926ba01ff5724c/coverage-7.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:454a380af72c6adada298ed270d38c7a391288198dbfb8467f786f588751a90c", size = 251059, upload-time = "2026-05-10T18:01:52.773Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca", size = 252716, upload-time = "2026-05-10T18:01:54.506Z" },
-    { url = "https://files.pythonhosted.org/packages/55/5c/0d3305d002c41dcde873dbe456491e663dc55152ca526b630b5c47efd62f/coverage-7.14.0-cp314-cp314-win32.whl", hash = "sha256:6a6516b02a6101398e19a3f44820f69bab2590697f7def4331f668b14adaf828", size = 222788, upload-time = "2026-05-10T18:01:56.487Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d", size = 223600, upload-time = "2026-05-10T18:01:58.497Z" },
-    { url = "https://files.pythonhosted.org/packages/00/70/a18c408e674bc26281cadaedc7351f929bd2094e191e4b15271c30b084cc/coverage-7.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:4b899594a8b2d81e5cc064a0d7f9cac2081fed91049456cae7676787e41549c9", size = 222168, upload-time = "2026-05-10T18:02:00.411Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/89/2681f071d238b62aff8dfc2ab44fc24cfdb38d1c01f391a80522ff5d3a16/coverage-7.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f580f8c80acd94ac72e863efe2cab791d8c38d153e0b463b92dfa000d5c84cd1", size = 220766, upload-time = "2026-05-10T18:02:02.313Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c7/c987babafd9207ffa1995e1ef1f9b26762cf4963aa768a66b6f0501e4616/coverage-7.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2bd259c442cd43c49b30fbafc51776eb19ea396faf159d26a83e6a0a5f13b0c", size = 221035, upload-time = "2026-05-10T18:02:04.017Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/e9/d6a5ac3b333088143d6fc877d398a9a674dc03124a2f776e131f03864823/coverage-7.14.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a706b908dfa85538863504c624b237a3cc34232bf403c057414ebfdb3b4d9f84", size = 262405, upload-time = "2026-05-10T18:02:05.915Z" },
-    { url = "https://files.pythonhosted.org/packages/38/b1/e70838d29a7c08e22d44398a46db90815bbcbf28de06992bd9210d1a8d8e/coverage-7.14.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7333cd944ee4393b9b3d3c1b598c936d4fc8d70573a4c7dacfec5590dd50e436", size = 264530, upload-time = "2026-05-10T18:02:07.582Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/73/5c31ef97763288d03d9995152b96d5475b527c63d91c84b01caea894b83a/coverage-7.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f162bc9a15b82d947b02651b0c7e1609d6f7a8735ca330cfadec8481dd97d5a", size = 266932, upload-time = "2026-05-10T18:02:09.401Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/76/dd56d80f29c5f05b4d76f7e7c6d47cafacae017189c75c5759d24f9ff0cc/coverage-7.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:362cb78e01a5dc82009d88004cf60f2e6b6d6fcbfdec05b05af73b0abf40118f", size = 268062, upload-time = "2026-05-10T18:02:11.399Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/c7/27ba85cd5b95614f159ff93ebff1901584a8d192e2e5e24c4943a7453f59/coverage-7.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:acebd068fca5512c3a6fde9c045f901613478781a73f0e82b307b214daef23fb", size = 261504, upload-time = "2026-05-10T18:02:13.257Z" },
-    { url = "https://files.pythonhosted.org/packages/13/2e/e8149f60ab5d5684c6eee881bdf34b127115cddbb958b196768dd9d63473/coverage-7.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:29fe3da551dface75deb2ccbf87b6b66e2e7ef38f6d89050b428be94afff3490", size = 264398, upload-time = "2026-05-10T18:02:15.063Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/7f/1261b025285323225f4b4abffa5a643649dfd67e25ddca7ebcbdea3b7cb3/coverage-7.14.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b4cc4fce8672fffcb09b0eafc167b396b3ba53c4a7230f54b7aaffbf6c835fa9", size = 262000, upload-time = "2026-05-10T18:02:16.756Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/dc/829c54f60b9d08389439c00f813c752781c496fc5788c78d8006db4b4f2b/coverage-7.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5d4a51aad8ba8bdcd2b8bd8f03d4aca19693fa2327a3470e4718a25b03481020", size = 265732, upload-time = "2026-05-10T18:02:18.817Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b0/70bd1419941652fa062689cba9c3eeafb8f5e6fbb890bce41c3bdda5dbd6/coverage-7.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9f323af3e1e4f68b60b7b247e37b8515563a61375518fa59de1af48ba28a3db6", size = 260847, upload-time = "2026-05-10T18:02:20.528Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/73/be40b2390656c654d35ea0015ea7ba3d945769cf80790ad5e0bb2d56d2ba/coverage-7.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a0abc7342ea9711c469dd8b821c6c311e6bc6aac1442e5fbd6b27fae0a8f3db", size = 263166, upload-time = "2026-05-10T18:02:22.337Z" },
-    { url = "https://files.pythonhosted.org/packages/29/55/4a643f712fcf7cf2881f8ec1e0ccb7b164aff3108f69b51801246c8799f2/coverage-7.14.0-cp314-cp314t-win32.whl", hash = "sha256:a9f864ef57b7172e2db87a096642dd51e179e085ab6b2c371c29e885f65c8fb2", size = 223573, upload-time = "2026-05-10T18:02:24.11Z" },
-    { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
-    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/24/efb17eb94018dd3415d0e8a76a4786a866e8964aa9c50f033399d23939c2/coverage-7.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e574801e1d643561594aa021206c46d80b257e9853087090ba97bed8b0a509d3", size = 220501, upload-time = "2026-06-22T23:08:02.182Z" },
+    { url = "https://files.pythonhosted.org/packages/76/93/32f1bfca6cdd34259c8af42820a034b7a28dfb44969a13ed38c17e0ba5b0/coverage-7.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f82b6bb7d75a2613e85d07cefa3a8c973d0544a8993337f6e2728e4a1e94c305", size = 221008, upload-time = "2026-06-22T23:08:03.701Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/88/0d0f974855ff905d15a64f7873d00bdc4182e2736267486c6634f4af293c/coverage-7.14.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2335ea5fed26af2e831094964fa3f8fae60b45f7e37fcc2d3b615b2add3ad87", size = 251420, upload-time = "2026-06-22T23:08:05.211Z" },
+    { url = "https://files.pythonhosted.org/packages/39/7f/117dd2ec65e4140576f8ef991d88220f9b806769f7a8c20e0550c0f924e2/coverage-7.14.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fbb8c3a98e779013786ae01d229662aeacbc77100efbd3f2f245219ace5af700", size = 253331, upload-time = "2026-06-22T23:08:06.672Z" },
+    { url = "https://files.pythonhosted.org/packages/87/55/f0bd6d6538e3f16829fb8a44b6c0d2fe9da638bbfdd6a20f8b5da8f4fa81/coverage-7.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac082660de8f429ba0ea363595abb838998570b9a7546777c60f413ab902bbde", size = 255441, upload-time = "2026-06-22T23:08:08.208Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/98/aa71f7879019c846a8a9662579ea4484b0202cf1e252ffeed647075e7eca/coverage-7.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac012839ff7e396030f1e94e10553a431d14e4de2ab65cb3acb72bbd5628ca2", size = 257398, upload-time = "2026-06-22T23:08:09.749Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/4f/5fd367e59844190f5965015d7bee899e67a89d13eb2760118479bf836f2f/coverage-7.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5952f8c1bda2a5347154450379316e6dfa4d934d62ca35f6784451e6f55074fb", size = 251558, upload-time = "2026-06-22T23:08:11.37Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/de/5383a6ee5a6376701fe07d980fa8e4a66c0c377fead16712720340d701a3/coverage-7.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8cf0f2509acb4619e2471a1951089054dd58ebea7a912066d2ea56dd4c24ca4a", size = 253134, upload-time = "2026-06-22T23:08:13.04Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/09542b1a99f788e3daec7f0fadc288821e71aca9ea298d51bfa1ba79fed5/coverage-7.14.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2e41fd3aab806770008279a93879b0924b16247e09ab537c043d08bbca53b4ab", size = 251195, upload-time = "2026-06-22T23:08:14.606Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9d/722fe8c13f0fbb064491b9e8656e56a606286792e5068c47ca1042e773e8/coverage-7.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f0a47095963cfe054e0df178daca95aec21e680d6076da807c3add28dfe920f7", size = 254959, upload-time = "2026-06-22T23:08:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/58/943627179ff1d82da9e54d0a5b0bb907bb19cf19515599ccd921de50b469/coverage-7.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a090cbf9521e78ffdb2fcf448b72902afe9f5923ff6a12d5c0d0120200348af9", size = 250914, upload-time = "2026-06-22T23:08:18.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d4/803efcbf9ae5567454a0c71e983589529448e2704ee0da2dc0163d482f18/coverage-7.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d310baf69a4fbe8a098ce727e4808a34866ac718a6f759ae659cbd3221358bc", size = 251824, upload-time = "2026-06-22T23:08:19.704Z" },
+    { url = "https://files.pythonhosted.org/packages/32/79/3f78ea9563132746eed5cecb75d2e576f9d8fec45a47242b5ae0950b82a3/coverage-7.14.3-cp311-cp311-win32.whl", hash = "sha256:74fdd718d88fe144f4579b8747873a07ec3f04cb837d5faec5a25d9e22fa31a8", size = 222594, upload-time = "2026-06-22T23:08:21.311Z" },
+    { url = "https://files.pythonhosted.org/packages/85/22/9ebbc5a2ab42ac5d0eea1f48648629e1de9bbe41ec243ed6b93d55a5a53f/coverage-7.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:cc96aa922e21d4bc5d5ed3c915cef27dfcbc13686f47d5e378d647fbfba655a2", size = 223073, upload-time = "2026-06-22T23:08:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/71/af/69d5fcc16cb555153f99cec5467922f226be0369f7335a9506856d2a7bd0/coverage-7.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:c66f9f9d4f1e9712eb9b1de5310f881d4e2188cfcba5065e1a8490f38687f2c4", size = 222617, upload-time = "2026-06-22T23:08:25.054Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b0/8a911f6ffe6974dac4df95b468ab9a2899d0e59f0f99a489afeec39f00bc/coverage-7.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d74ff26299c4879ce3a4d826f9d3d4d556fd285fde7bbce3c0ef5a8ab1cec24", size = 220672, upload-time = "2026-06-22T23:08:26.621Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/0fc0cb52538783dbbae0934b834f5a58fd5354380ee6cad4a07b15dc845d/coverage-7.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:96150a9cf3468ea20f0bc5d0e21b3df8972c31480ef90fa7614b773cc6429665", size = 221035, upload-time = "2026-06-22T23:08:28.372Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e2/421ccfbb48335ac49e93301478cf5d623b0c2bf1c0cadd8e2b2fc6c0c710/coverage-7.14.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:27d07a46500ba23515b838dbcf52512026af04090755cf6cc64166d88c9b9a1a", size = 252540, upload-time = "2026-06-22T23:08:30.226Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c2/05b8c890097c61a7f4406b35396b997a635200ded0339eda83dfbe526c5f/coverage-7.14.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:621e13c6108234d7960aaf5762ab5c3c00f33c30c15af06dcbff0c73bf112727", size = 255274, upload-time = "2026-06-22T23:08:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/b6d9efe447f8ba3c3c854195f326bd64c54b907d936cd2fdebf8767ec72e/coverage-7.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b60ca6d8af70473491a15a343cbabab2e8f9ea66a4376e81c7aa24876a6f977", size = 256389, upload-time = "2026-06-22T23:08:33.843Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/f26e50acc429e608bc534ac06f0a3c169019c798178ec5e9de3dbc0df9c9/coverage-7.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c90a7cdd5e380e1ce02f19792e2ac2fbfbf177e35a27e69fd3e873b30d895c0c", size = 258648, upload-time = "2026-06-22T23:08:35.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a2/01c1fabf816c8e1dae197e258edf878a3d3ddc86fbda34b76e5794277d8f/coverage-7.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d788e5fd55347eef06ca0732c77d04a264de67e8ff24631270cdff3767a60cf", size = 252949, upload-time = "2026-06-22T23:08:37.562Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/941166dd79c31fd44a13063780ae8d552eee0089a0a0930b9bdb7df554ed/coverage-7.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62c7f79db2851c95ef020e5d28b97afde3daf9f7febcd35b53e05638f729063f", size = 254310, upload-time = "2026-06-22T23:08:39.174Z" },
+    { url = "https://files.pythonhosted.org/packages/10/31/80b1fd028201a961033ce95be3cd1e39e521b3762e6b4a1ac1616cb291e7/coverage-7.14.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:90f7608aeb5d9b60b523b9fb2a4ee1973867cc4865a3f26fe6c7577073b70205", size = 252453, upload-time = "2026-06-22T23:08:40.84Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/c3d9addd94c4b524f3f4af0232075f5fe7170ce99a1386edff803e5934db/coverage-7.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e3b91f9c4740aeb571ecf82e5e8d8e4ab62d34fcb5a5d4e5baa38c6f7d2857c", size = 256522, upload-time = "2026-06-22T23:08:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/91/14/e5a0575f73795af3a7a9ae13dadf812e17d32422896839987dc3f86947e1/coverage-7.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c946099774a7699de03cbd0ff0a64e21aed4525eed9d959adde4afe6d15758ef", size = 252023, upload-time = "2026-06-22T23:08:44.243Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9b/9652ee531937ce3b8a63a8896885b2b4a2d56adc30e53c9540c666286d88/coverage-7.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:16b206e521feb8b7133a45754643dead0538489cf8b783b90cf5f4e3299625fd", size = 253893, upload-time = "2026-06-22T23:08:46.113Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/05/42678841c8c38e4b08bdfc48269f5a16dfbf5806000fe6a89b4cece3c691/coverage-7.14.3-cp312-cp312-win32.whl", hash = "sha256:ea3169c7116eb6cdf7608c6c7da9ecfcb3da40688e3a510fac2d1d2bafd6dc35", size = 222734, upload-time = "2026-06-22T23:08:47.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/87/07a4fcee55177a25f1b52331a8e92cf4f2c53b1a9c75ce2981fd59c684ad/coverage-7.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:7ea52fc08f007bcc494d4bb3df3851e95843d881860ba38fe2c64dc100db5e7d", size = 223266, upload-time = "2026-06-22T23:08:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/34/2b8b66a989282ea7b370beb49f50bab29470dc30bb0b03935b6b802782f7/coverage-7.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:8cec0ad652ec57790970d817490105bd917d783c2f7b38d6b58a0ca312e1a336", size = 222655, upload-time = "2026-06-22T23:08:51.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/83/7fefbf5df23ed2b7f489907564a7b34b9b07098128e12e0fdfa92626e456/coverage-7.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47968988b367990ae4ab17523790c38cd125e02c6bfd379b6022be2d40bdc38c", size = 220699, upload-time = "2026-06-22T23:08:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/38c3653ff6d56d704b29241362387ca824e38e15b76fdcb7096538195790/coverage-7.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a", size = 221068, upload-time = "2026-06-22T23:08:55.571Z" },
+    { url = "https://files.pythonhosted.org/packages/20/86/4f5c45d51c5cd10a128933f0fd235393c9146abbfd2ce2dfa68b3267ead3/coverage-7.14.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fa9e5c6857a7e80fa22ace5cf3550ae392bbfc322f1d8dd2d2d5a8be38cec027", size = 252060, upload-time = "2026-06-22T23:08:57.464Z" },
+    { url = "https://files.pythonhosted.org/packages/82/50/dfce42eff2cecabcd5a9bbad5489449c87db3415f408d23ffee417ce01f6/coverage-7.14.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73", size = 254657, upload-time = "2026-06-22T23:08:59.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d2/639ceb1bc8038fd0d66768278d5dc22df3391918b8278c2a21aa2602a531/coverage-7.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9", size = 255892, upload-time = "2026-06-22T23:09:01.291Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/96/002094a10e113512500dc1e10430a449417e17b0f90f7d496bcb820208b7/coverage-7.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de", size = 258026, upload-time = "2026-06-22T23:09:03.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ec/286a5d2fad9c4bee59bd724feeb7d5bf8303c6c9200b51d1dd945a9c72b0/coverage-7.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd", size = 252285, upload-time = "2026-06-22T23:09:04.773Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7d/a17753a0b12dd48d0d50f5fab079ad99d3be1eac790494d89f3a417ca0b9/coverage-7.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5", size = 254023, upload-time = "2026-06-22T23:09:06.513Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/a76c6ceba6a2c313f905310abf2701d534cada22d372db11731831e9e209/coverage-7.14.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:de76caefc8deabb0dd1678b6a980be97d14c8d87e213ac194dbf8b09e96d63fb", size = 251989, upload-time = "2026-06-22T23:09:08.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/39/353013a75fec0fb49f7553519f9d52b4441e902e5178c93f38eb6c07cedb/coverage-7.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f", size = 256144, upload-time = "2026-06-22T23:09:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0e/613878555d734def11c5b20a2701a15cb3781b9e9ea749da27c5f436e928/coverage-7.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498", size = 251808, upload-time = "2026-06-22T23:09:12.057Z" },
+    { url = "https://files.pythonhosted.org/packages/af/76/359c058c9cfdcf1e8b107663881225b03b364a320017eda24a2a66e55102/coverage-7.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0", size = 253579, upload-time = "2026-06-22T23:09:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d9/4ba2f060933a30ebe363cef9f67a365b0a317e580c0d5d9169d56a73ef1c/coverage-7.14.3-cp313-cp313-win32.whl", hash = "sha256:338b19131ab1a6b767b462bfcbaa692e7ae22f24463e39d49b02a83410ff6b37", size = 222741, upload-time = "2026-06-22T23:09:15.636Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e8/196ebc25d8f34c06d43a6e9c8513c9266ef8dbf3b5672beb1a00cf5e29fa/coverage-7.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:b3d77f7f196abdef7e01415de1bce09f216189e83e58159cfeef2b92d0464994", size = 223283, upload-time = "2026-06-22T23:09:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/51d2aac6417523a286f10fb25f09eb9518a84df9f1151e93ff6871f34849/coverage-7.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:e6230e688c7c3e65cedd41a774eb4ec221adc6bfee13768231015b702d5e4150", size = 222678, upload-time = "2026-06-22T23:09:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/61/56/14e3b97facbfa1304dd19e676e26599ad359f04714bed32f7f1c5a88efdc/coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc", size = 220741, upload-time = "2026-06-22T23:09:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7", size = 221068, upload-time = "2026-06-22T23:09:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f0/3f8421b20d9c4fcd39be9a8ca3c3fda8bc204b44efbd09fede153afd3e2f/coverage-7.14.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce", size = 252117, upload-time = "2026-06-22T23:09:25.458Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ca/59ea35fb99743549ec8b37eff141ece4431fea590c89e536ed8032ef45cf/coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5", size = 254622, upload-time = "2026-06-22T23:09:27.523Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/ec6de51ae7493b92a1cf74d1b763121c29636759167e2a593ba4db5881e4/coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a", size = 255968, upload-time = "2026-06-22T23:09:29.43Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/05/c8bfc77823f42b4664fb25842f13b567022f6f84a4c83c8ecbb16734b7cb/coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501", size = 258284, upload-time = "2026-06-22T23:09:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/15/1d1b242027124a32b26ef01f82018b8c4ef34ef174aa6aeba7b1eeef48e8/coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e", size = 252143, upload-time = "2026-06-22T23:09:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b6/d2a9842fd2a5d7d27f1ac851c043a734a494ad75402c5331db3da79ed691/coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3", size = 253976, upload-time = "2026-06-22T23:09:35.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/30/e1600ddf7e226db5558bb5323d2186fff00f505c4b764643ec89ce5d8175/coverage-7.14.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5", size = 251942, upload-time = "2026-06-22T23:09:37.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2c/9159de64f9dd648e324328d588a44cfab1e331eb5259ce1141afe2a92dfb/coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845", size = 256220, upload-time = "2026-06-22T23:09:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/91/67/b7f536cc2c124f48e91b22fbb741d2261f4e3d310faf6f76007f47566e5d/coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027", size = 251756, upload-time = "2026-06-22T23:09:41.056Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ec/f3718038e2d4860c715a55428377ca7f6c75872caf98cabd982e1d76967d/coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b", size = 253413, upload-time = "2026-06-22T23:09:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a5/91f11efeef89b3cc9b30461128db15b0511ef813ab889a7b7ab636b3a497/coverage-7.14.3-cp314-cp314-win32.whl", hash = "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965", size = 222946, upload-time = "2026-06-22T23:09:45.261Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fd/98ac9f524d9ec378de831c034dbdeb544ca7ef7d2d9c9996daf232a037fd/coverage-7.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3", size = 223436, upload-time = "2026-06-22T23:09:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a0/7cd612d650a772a0ae80144443406bf61981c896c3d57c9e6e79fb2cdbd1/coverage-7.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92", size = 222861, upload-time = "2026-06-22T23:09:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/55/57/017353fab573779c0d00448e47d102edd36c792f7b6f233a4d89a7a08384/coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949", size = 221474, upload-time = "2026-06-22T23:09:51.417Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/90cf1f1a5c468a9c1b7ba2716e0e205293ad9b02f5f573a6de4318b15ba1/coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891", size = 221738, upload-time = "2026-06-22T23:09:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c0/4df964fa539f8399fd7679c09c472d73744de334686fd3f01e3a2465ce4e/coverage-7.14.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388", size = 263101, upload-time = "2026-06-22T23:09:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/06/76/e5d33b2576ae3bf2be2058cd1cae57774b61e400f2c3c58f3783dc2ffb4a/coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784", size = 265225, upload-time = "2026-06-22T23:09:57.904Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/e52419afe391a39ba27fdefaf0737d8e34bf03faef6ab3b3006545bbd0d0/coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed", size = 267643, upload-time = "2026-06-22T23:09:59.938Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7a/f2625d8d5006b6b20fba5afaef00b24a763fe96476ea798a3076cbc1f84e/coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5", size = 268762, upload-time = "2026-06-22T23:10:01.943Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bf/908024006bba57127354d74e938954b9c3cd765cc2e0412dc9c37b415cda/coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26", size = 262208, upload-time = "2026-06-22T23:10:03.954Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a0/d4f9296441b909817442fdb26bd77a698f08272ec683a7394b00eb2e47a0/coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889", size = 265096, upload-time = "2026-06-22T23:10:05.936Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/da/4ae4f3f4e477b56a4ce1e5c48a35eff38a94b50130ce5bdc897024741cfc/coverage-7.14.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d", size = 262699, upload-time = "2026-06-22T23:10:07.973Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7a/6927148073ff32856d78baa77b4ddc07a9be7e90020f9db0661c4ca523a1/coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e", size = 266433, upload-time = "2026-06-22T23:10:10.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a7/774f658dbe9c4c3f5daa86a87e0459ac3832e4e3cc67affe078547f727b9/coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7", size = 261547, upload-time = "2026-06-22T23:10:12.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/14/a0c18c0376c43cbf973f43ef6ca20019c950597180e6396232f7b6a27102/coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635", size = 263859, upload-time = "2026-06-22T23:10:14.492Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ac/43a3d0f460af524b131a6191805bc5d18b806ab4e828fbf82e8c8c3af446/coverage-7.14.3-cp314-cp314t-win32.whl", hash = "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc", size = 223250, upload-time = "2026-06-22T23:10:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5f/d5e5c56b0712e96ce8f69fe7dbf229ff938b437bc50862743c8a0d2cea84/coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda", size = 224082, upload-time = "2026-06-22T23:10:19.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/35/947cbd5be1d3bcbbdc43d6791de8a56c6501903311d42915ae06a82815f0/coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f", size = 223400, upload-time = "2026-06-22T23:10:21.24Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e3/a0aa32bfa3a081951f60a23bc0e7b512891ef0eecda1153cf1d8ba36c6b1/coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8", size = 212469, upload-time = "2026-06-22T23:10:23.405Z" },
 ]
 
 [package.optional-dependencies]
@@ -438,84 +428,81 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "48.0.1"
+version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
-    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
-    { url = "https://files.pythonhosted.org/packages/42/06/3e768b4c3bc78201583fa35a0e18f640dd782ff41afba88f8545481a8874/cryptography-48.0.1-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:f817adc181390bd54f2f700107a7419040fb7c1bdf2fc26f36551a06a68c3345", size = 7989830, upload-time = "2026-06-09T22:31:07.8Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/13/6476736484b94041110c8340a3eb63962fea4975baea8cb4a512adb44d4d/cryptography-48.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d5d30989c6917b478b5817902e85fddaea2261efa8648383d965381ccb9e1ac4", size = 4689201, upload-time = "2026-06-09T22:31:09.745Z" },
-    { url = "https://files.pythonhosted.org/packages/79/62/65a87f34d2a431546e2509b85d55e8c90df86d668f6731da64d538512ac2/cryptography-48.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df637c05205ea7c1d7fbcbe54bbfea648a52951155f997af13d895d0ecc96991", size = 4702822, upload-time = "2026-06-09T22:32:24.409Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/59/810b5204b0a9b10f4b6bc06bd551a8b609803cd931806bc3b71884b225e5/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:869c3b8a53bfe27147832df48b32adadf558249d50e76cb3769d40e986b13265", size = 4694875, upload-time = "2026-06-09T22:32:08.737Z" },
-    { url = "https://files.pythonhosted.org/packages/24/dc/d8ca05ffea724eec6d232ea6f18e74c269eb6bdfdcc9bfba689790d1325f/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:e361afba8918070d376df76f408a4f67fec0ee9cff81a99e48fe9a233ef59e17", size = 5290385, upload-time = "2026-06-09T22:31:15.212Z" },
-    { url = "https://files.pythonhosted.org/packages/03/8c/3be6cb4da181f5bb6c19cf560c2359d60644a6b5fc5b57854e528f47b296/cryptography-48.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d069066deead00ac7f090be101be875a06855908f7ec004c27b8fefb4acfb411", size = 4737082, upload-time = "2026-06-09T22:32:22.66Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/f6/d5f60a5a1434dbfd949e227fd0065d194c7e6b6ac526b17f5c06152b8231/cryptography-48.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:09f73a725d582cef64b91281a322cd798d14a33b2b6f2b7ad9531dc336d84c02", size = 4325328, upload-time = "2026-06-09T22:32:10.777Z" },
-    { url = "https://files.pythonhosted.org/packages/17/b7/ba75dd947a14b6ad907b01ae8f6b5b348cdd1b48142f0063dee9e20c1d9d/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:15254441469dd6bf027039453288e2072124f8b6603563f5d759e1c9b69273fa", size = 4694530, upload-time = "2026-06-09T22:31:53.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/50d6b9e8aff12d8b67afaeb3569335e32dc83a5723e3bbded24fdac9f809/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:8ace4507d1e6533c125f4fac754f8bb8b6a74c08e92179dabd7e16571a3efbf3", size = 5245046, upload-time = "2026-06-09T22:31:25.774Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/04/618f4115cfc0add0838c82507aa18a346089428da8653ad38b3ff36f5cb3/cryptography-48.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b4e391975f038e66432328639620a4aff2d307513b004f1ca06d6225bced815c", size = 4736660, upload-time = "2026-06-09T22:32:12.676Z" },
-    { url = "https://files.pythonhosted.org/packages/24/9c/06e062462a0de28a3b3911322eded4c16deb9f441b1b7575d3dc59488ab5/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:42fcd8e26fe555d9b3577a135f5091fefa0aa4e99129c23fb56787a1bd4ada72", size = 4822229, upload-time = "2026-06-09T22:31:17.062Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/be/0561971eaaee4b8a0e7d5113c536921063ab91aaf23278ac374eaf881e11/cryptography-48.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1400da5e32a43253392277eac7490a60e497d810a63dd5608d71bbd7af507c9", size = 4966364, upload-time = "2026-06-09T22:31:32.842Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/27/728c77876f12b000820b69ae490f3c4083775e79e07827e9e60be07ad209/cryptography-48.0.1-cp314-cp314t-win32.whl", hash = "sha256:0df56b056bc17c1b7d6821dfa65216e62bd232d8ab05eb3db44e71d235651471", size = 3278498, upload-time = "2026-06-09T22:31:29.154Z" },
-    { url = "https://files.pythonhosted.org/packages/06/e3/79a612c6d7b1e6ee0edd43633d53035bec2cfb78c82b76f7864f39e36f34/cryptography-48.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:9de21387aa95e2a895823d0745b430bed4f33503ba9ab5e0b5311f33e37d66d2", size = 3798790, upload-time = "2026-06-09T22:31:56.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
-    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
-    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
-    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/d3/eb4e394e587341fdad09a09101fa76478ead3a78b0ad63e55c22f0d75c02/cryptography-48.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:08a597acce1ff37f347400087776599e2348a3a8bc53b44120e463cd274efe4a", size = 3951747, upload-time = "2026-06-09T22:31:23.871Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/4a/3f43451b4f858bfceaaaffc649e6e787e8d4fb332a1d443af39ab02cc8f1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:735824ec41b7f74a7c45fb1591349333e4c696cb6c044e5f46356e560143e4cd", size = 4641226, upload-time = "2026-06-09T22:31:02.532Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4e/855584c2c23b09e4ce2d3b9c30e983e679cd60b068c513c6bbdb91e11782/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:92a46e1d638daa264ba2971c0b0489c9409787943efae4d60ffda3d091ef832c", size = 4668958, upload-time = "2026-06-09T22:32:06.213Z" },
-    { url = "https://files.pythonhosted.org/packages/42/3b/d35750e41d803d1e516fd6d6011f065424924da7af1748cef4cc9cb3ede1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:7e234ac052af99f2700826a5c29ea99d9c1b1f80341cde62d11c8154dc8e0bd9", size = 4640793, upload-time = "2026-06-09T22:32:26.331Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/aa/cdb7181fe865285e87e96825aaab239400f1de0c3bfba9bd9769b79f1a92/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:33842cf0888951cef5bc7ac724ab844a42044c1727b967b7f8997289a0464f92", size = 4668505, upload-time = "2026-06-09T22:31:27.534Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8c/ce3823c06c2804f194f9e64f0d67fa3f4094a39f2bb1a990cd03603af8fc/cryptography-48.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6184ca7b174f28d7c703f1290d4b297217c45355f77a98f67e9b7f14549ac54a", size = 3742204, upload-time = "2026-06-09T22:31:34.773Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d3/4a83af35d65e3fad632c926fad684c193ea4398569ccb0bbbc7fe8f5dc9a/cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b", size = 3993685, upload-time = "2026-06-12T20:02:14.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a7/f9dac0ab7f80368c56993a7bf638ef9935f825c91902798481fac0898138/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838", size = 4676239, upload-time = "2026-06-12T20:02:28.793Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/70/2ba3769dd0ae167e2f33dfa9592d45db6ff9a61d62ca1a5b3d1bdd09068f/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5", size = 4715584, upload-time = "2026-06-12T20:01:27.495Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/2923570ac1c0bd3a737aa366ac3abbbbde273042308b8cde95e2364a6e6a/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615", size = 4675885, upload-time = "2026-06-12T20:01:55.49Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f8/614dc7e051418cfe53d55173c1e24c6b0085e89996fe90508c2fdf769aef/cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6", size = 4715449, upload-time = "2026-06-12T20:02:05.469Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/50/a9caea39ad19c431c1a3f8a31114df65b260cdfe67786b6c7e7c040c4c44/cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6", size = 3783731, upload-time = "2026-06-12T20:02:43.319Z" },
 ]
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
 ]
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
 ]
 
 [[package]]
 name = "google-api-core"
-version = "2.30.3"
+version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
@@ -524,22 +511,22 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
 ]
 
 [[package]]
 name = "google-auth"
-version = "2.53.0"
+version = "2.55.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/1c/70b23fc52b2bb3c70b379f3bd05c4a60ab3a873e30c6bd21c57e0154848a/google_auth-2.55.0.tar.gz", hash = "sha256:fcd3a130f575fa36403d38774af1c64a4fbfbca09215f0589d2372b5119697cb", size = 349379, upload-time = "2026-06-15T22:33:16.466Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+    { url = "https://files.pythonhosted.org/packages/44/71/c0321dc6d63d99946da45f7c06299b934e4f7f7da5c4f14d101bcb39adf1/google_auth-2.55.0-py3-none-any.whl", hash = "sha256:a17cef9dedf98c4ebae2fb0c48c8f75952c877cbc2efe09f329ef16c2783d88a", size = 252400, upload-time = "2026-06-15T22:33:14.992Z" },
 ]
 
 [[package]]
@@ -557,7 +544,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "3.10.1"
+version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -567,9 +554,9 @@ dependencies = [
     { name = "google-resumable-media" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/47/205eb8e9a1739b5345843e5a425775cbdc472cc38e7eda082ba5b8d02450/google_cloud_storage-3.10.1.tar.gz", hash = "sha256:97db9aa4460727982040edd2bd13ff3d5e2260b5331ad22895802da1fc2a5286", size = 17309950, upload-time = "2026-03-23T09:35:23.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/ff/ca9ab2417fa913d75aae38bf40bf856bb2749a604b2e0f701b37cfcd23cc/google_cloud_storage-3.10.1-py3-none-any.whl", hash = "sha256:a72f656759b7b99bda700f901adcb3425a828d4a29f911bc26b3ea79c5b1217f", size = 324453, upload-time = "2026-03-23T09:35:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl", hash = "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c", size = 340605, upload-time = "2026-06-12T18:03:12.677Z" },
 ]
 
 [[package]]
@@ -604,14 +591,14 @@ wheels = [
 
 [[package]]
 name = "google-resumable-media"
-version = "2.9.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-crc32c" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/4b/0b235beccc310d0a48adbc7246b719d173cca6c88c572dfa4b090e39143c/google_resumable_media-2.9.0.tar.gz", hash = "sha256:f7cfb224846a9dd444d125115dfbe8ef02a2b893e78f087762fe716a255a734b", size = 2164534, upload-time = "2026-05-07T08:04:44.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/73/3518e63deb1667c5409a4579e28daf5e84479a87a72c547e0487f7883dcd/google_resumable_media-2.9.0-py3-none-any.whl", hash = "sha256:c8901e88e389af8bed64d9696c74d8bad961865eb2236e13e0bfca9bb0a65ca3", size = 81507, upload-time = "2026-05-07T08:03:23.809Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
 ]
 
 [[package]]
@@ -637,11 +624,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -770,6 +757,11 @@ wheels = [
 name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
@@ -846,6 +838,68 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561", size = 16789987, upload-time = "2026-06-21T20:56:16.657Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6", size = 11760322, upload-time = "2026-06-21T20:56:19.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be", size = 5319605, upload-time = "2026-06-21T20:56:22.173Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2", size = 6653628, upload-time = "2026-06-21T20:56:23.914Z" },
+    { url = "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8", size = 15153691, upload-time = "2026-06-21T20:56:25.631Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a", size = 16660066, upload-time = "2026-06-21T20:56:28.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0", size = 16514638, upload-time = "2026-06-21T20:56:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54", size = 18419647, upload-time = "2026-06-21T20:56:32.41Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/f5d1676b1d7fb682eb5e9a1641e7ebd2414b3216c370661d1029778908b4/numpy-2.5.0-cp312-cp312-win32.whl", hash = "sha256:6206db0af545d73d068add6d992279145f158428d1da6cc49adc4b630c5d6ee5", size = 6056688, upload-time = "2026-06-21T20:56:34.657Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/48f115d1c58a34032facebcd51fdf2d02df2c51d4a46a81dd1197bb2ea6b/numpy-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f2d6873e2940c860a309d21e25b1e69af6aaffdd80aa056b04c16380db1c4f2", size = 12419237, upload-time = "2026-06-21T20:56:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/2e0882f4044d1b1a1b63e875151fb2393389032022a8b7f5657a7996d3b2/numpy-2.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:a55e1eb2bca2cfd17a16b213c99dfc8502d47b0d494224d2122277d0400935ca", size = 10339912, upload-time = "2026-06-21T20:56:38.733Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -859,7 +913,8 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "python-dateutil" },
     { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
@@ -931,11 +986,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -949,30 +1004,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.40.1"
+version = "1.42.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/91/a1d7809a6d399f0aa78d4d3a4f4daf411cb97ccfe7f236c08a01be5fc8a5/polars-1.42.0.tar.gz", hash = "sha256:283ddc923e47857924fbef36580d2e98d984a47c962bae4cbce9c0ebcc98989c", size = 740984, upload-time = "2026-06-24T05:20:13.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4d/094819d251f2248999cb722125fd4e44ee79b753fe535338cbf442fbf45d/polars-1.42.0-py3-none-any.whl", hash = "sha256:ab10cac3f2d28a6e22e22bcac69c0e51fb33cd25aee1f45105782d4fe55a3e6a", size = 836855, upload-time = "2026-06-24T05:18:18.204Z" },
 ]
 
 [[package]]
 name = "polars-runtime-32"
-version = "1.40.1"
+version = "1.42.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/67/20759e9abbc61910cf948f5c28986ab25ef9e8009099b469d64d6a34a478/polars_runtime_32-1.42.0.tar.gz", hash = "sha256:c927e1930881fe0bf9629d12e5d44ebd4ecef2bfa02374dfc79feaa24054394f", size = 3042711, upload-time = "2026-06-24T05:20:15.715Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
-    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
-    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/62/8b83fca67d478e4a2b88cbba2fbff4d533052938ff96d598b7915fd9d235/polars_runtime_32-1.42.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d235a5e8349797c16b70ad573fb9ddbd7f162796884bcbd25260908f8408affc", size = 53112358, upload-time = "2026-06-24T05:18:22.275Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/72/06d3d78b7e8e8d3c72ea9eee310950334d50986462b3c1d40f82972495a5/polars_runtime_32-1.42.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e7923db3bcb57e0edecde3be28629e0411414a15ef1a4c10c783ac5eadab2e1e", size = 47443757, upload-time = "2026-06-24T05:18:26.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/77/20241aaf919a0f63b946fb702bc14447db290ef918e2c2943ed90d50fcc1/polars_runtime_32-1.42.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42e27e2eb5909abcedb4ab4cc04ee67c5ec2b73a5640ebd8739b1b719383fa68", size = 51360855, upload-time = "2026-06-24T05:18:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5c/ca14606a42628b04d82ac6ae5742ed24048bd43fbf48ae87fc4f4b9e759d/polars_runtime_32-1.42.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a3c43d4a76360bf912f8772b5ac1c23d5a8efef71408c63bba1bb0b4897a8ea", size = 57299346, upload-time = "2026-06-24T05:18:35.374Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/af/3ad0de43bbb97e91d605d7d76acb30be36269b8a8402890ab4f9892b6e26/polars_runtime_32-1.42.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:542a77b2b969e5157939bfb76cd0f372c4f42db6ccd58636fcefe0011162a418", size = 51512143, upload-time = "2026-06-24T05:18:39.771Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a5/d1133ba9d005532a6fb94544f5da09e497a8fe42c04e37c3da6faa80bd67/polars_runtime_32-1.42.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a13949abfce319de7fc4c1abee43bc9d4a4ed4d96bcc1a6037d022e4e9561d9f", size = 55214521, upload-time = "2026-06-24T05:18:43.916Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/54/0b8355ab29669560608b2864a5e54674dd78bbd48c04976607516e081107/polars_runtime_32-1.42.0-cp310-abi3-win_amd64.whl", hash = "sha256:91a07bd852c1d1ea19b3e27c974bc7b1b29ac948fdb2e785da3a6ec0f0683cad", size = 52718509, upload-time = "2026-06-24T05:18:48.202Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/7c46fdbd1dbbaaf77f9512d7665609d7e4c4d8c8849edb9a16c471041075/polars_runtime_32-1.42.0-cp310-abi3-win_arm64.whl", hash = "sha256:b7c5d7721b7bb2563d72785050ac099da1e2000d412f9c72a0cfb7b07779e75d", size = 46728464, upload-time = "2026-06-24T05:18:52.505Z" },
 ]
 
 [[package]]
@@ -1005,17 +1060,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "7.35.0"
+version = "7.35.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/60/fd/5b1491d9e4b586d621c54f4c36b888714164b6875f8d6afa3f9072906a51/protobuf-7.35.0.tar.gz", hash = "sha256:a2efd84605f41e559f1881b0912b44099d0a2ac9bf46b3474823f10fb393b0e6", size = 458677, upload-time = "2026-05-19T23:02:29.197Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/ee/93d06e358a4aa32280b00e722d3ea0a1f25fc3cc5778d80581c9cca2c10e/protobuf-7.35.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:66be6c513931c794fa92c080ffee41671390da3d79da219cf9c0c0907f035dda", size = 433225, upload-time = "2026-05-19T23:02:19.884Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5", size = 328847, upload-time = "2026-05-19T23:02:22.3Z" },
-    { url = "https://files.pythonhosted.org/packages/91/1a/39f7ce90a238c1a987a4d81ec26379e02ca0aff367de68e4a1fa474215b9/protobuf-7.35.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4cbf5cc286130e06a6c9bbefac442431173906dfcc979712183d4adcc01b37ee", size = 344030, upload-time = "2026-05-19T23:02:23.591Z" },
-    { url = "https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011", size = 327130, upload-time = "2026-05-19T23:02:24.637Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e5/e46adb0badc388bfb84877a5f9f026aff63f60e611016cf64dbe77e05446/protobuf-7.35.0-cp310-abi3-win32.whl", hash = "sha256:4c4617b83ade0e279d1d2bfe04025a1adb87f9ed657de038620dc0ff959357f6", size = 428946, upload-time = "2026-05-19T23:02:25.741Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ab/547fbd9e16d879dd13c167478f8ae0a83a428008ca07a5e06acdc23ad473/protobuf-7.35.0-cp310-abi3-win_amd64.whl", hash = "sha256:f05bcadf9a2a6b8dda047007075135fb7d08c73d9177aabc067e1be46881a201", size = 439996, upload-time = "2026-05-19T23:02:26.808Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/ef/50433d346c56657a70d27f156c7b349ac59a068b01de4eb796e747eecc43/protobuf-7.35.0-py3-none-any.whl", hash = "sha256:c13f325cf242bad135c350629eeb5d54b24228eb472fb3e2e9ebbd4c5dc20ca0", size = 171659, upload-time = "2026-05-19T23:02:27.842Z" },
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -1118,7 +1173,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1127,9 +1182,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1173,15 +1228,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.3.1"
+version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
 ]
 
 [[package]]
@@ -1256,39 +1311,39 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.13"
+version = "0.15.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/e6/15800dfde183a1a106594016c912b4c12d050a301989d1aca6cb63759fe8/ruff-0.15.19.tar.gz", hash = "sha256:edc27f7172a93b32b102687009d6a588508815072141543ae603a8b9b0823063", size = 4772071, upload-time = "2026-06-24T01:10:46.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
-    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
-    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
-    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4c/9ded7626c39a0440c575bf69e2bf500d443388272c842662c59852ee7fcd/ruff-0.15.19-py3-none-linux_armv6l.whl", hash = "sha256:922d1eb283161564759bd49f507e91dc6112c15da8bd5b84ed714e086243cf86", size = 10950859, upload-time = "2026-06-24T01:10:38.491Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ef/c211505ece1d00ef493d58e54e3b6383c946a21e9874774eb531f2512cf3/ruff-0.15.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4d190d8f62a0b94aba8f721116538a9ee29b1e74d26650846ba9b99f0ae21c40", size = 11294529, upload-time = "2026-06-24T01:10:36.481Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/78d462e7d39968e58094dc57be7d09ffb14ce37da5b68ed70338a35a1f21/ruff-0.15.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a2c86ba6870dd415a9d9eb8be94d7924ebec6a26ffc7958ec7ca29d4bff967d", size = 10641416, upload-time = "2026-06-24T01:10:48.923Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c4/5cb66cfd1f865d5cca908b86c93ac785e7f572193d3c7426079ca6643e24/ruff-0.15.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b432bc087264aea70fd25ac198918b70bd9e2aa0db4297b0bb91bbfbbc63ce", size = 11015582, upload-time = "2026-06-24T01:10:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9f/8ecfaec10cf5eecd28fbc00ff4fb867db90a1be54bf3d39ebf93f893cd52/ruff-0.15.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8530a09d03b3a8c994f8b559a7dcdabc690bcd3f78ef276c38c83166798ebf56", size = 10744059, upload-time = "2026-06-24T01:10:32.48Z" },
+    { url = "https://files.pythonhosted.org/packages/35/6b/983249d04562bc2d590edd75f32455cdb473affb3ba4bc8d883e939c697d/ruff-0.15.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87bf21fb3875fe69f0eacc825411657e2e85589cce633c35c0adf1113649c62b", size = 11568461, upload-time = "2026-06-24T01:10:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/39/bc7794f127b18f492a3b4ee82bba5a900c985ff13b72b46f46e3c171ba34/ruff-0.15.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b229cb3ef56ecc2c1c8ebeca64b7a7740ccaef40a9eb097e78dde5a8560b83", size = 12429690, upload-time = "2026-06-24T01:10:40.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3b/0de6859e698ed11c8a49e765196c8d333599b6a546c0715df39b6ba1aa2e/ruff-0.15.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6c754515be7b76afe6e7e62df7776709571bcfc1631183828afcf3bafa869e3", size = 11693067, upload-time = "2026-06-24T01:10:25.681Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3d/0b1f30f84bee9ae6ae8d349c2ba8b6f4b040966744efdd3acc804ae7c024/ruff-0.15.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a498f82e0f4d8904c4e0aea5139cdfac1f39d19a3c51d491292f63a36e83b2e", size = 11616911, upload-time = "2026-06-24T01:10:44.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/eb/c90bd3dfc12eed9032c2c1bfe05105b93a1b2c8bce555db6308315b853ce/ruff-0.15.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d48caa34488fb521fd0ef4aea2b0e8fe758298df044138f0d67b687a6a0d07ed", size = 11649343, upload-time = "2026-06-24T01:10:23.472Z" },
+    { url = "https://files.pythonhosted.org/packages/82/91/01caa13602a2f12fae5edbe8caf78b3c1e6db1293132aee6959eecce095c/ruff-0.15.19-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4171b6613effa9363cd46dd4f75bd1827b6d1b946b5e278ed0c600d305379445", size = 10977610, upload-time = "2026-06-24T01:10:50.892Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/acb817922feab9ecbb3201377d4dbe7a25f1395e46545820061973f03468/ruff-0.15.19-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:27c15b2a241dd4d995557949a094fe78b8ad99122a38ccae1595849bcc947b3f", size = 10744900, upload-time = "2026-06-24T01:10:42.726Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bc/5c8ca46b8a7a3f2b16cfbec88721d772b1c93912904e8f8c2e49470fea63/ruff-0.15.19-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ed03b7862d68f0a8771d50ee129980cbf1b113f96e250b73954bc292f689e0bb", size = 11293560, upload-time = "2026-06-24T01:10:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e0/4a888cbe4d5523b3f77a2b1fa043f46cfeba1b32eac35dcfadee0578fa8a/ruff-0.15.19-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:08143f0685ae278b30727ea72e90c61e5bd9c31b91aac4f5bb989538f73d24b8", size = 11696533, upload-time = "2026-06-24T01:10:53.046Z" },
+    { url = "https://files.pythonhosted.org/packages/98/43/c34b2fcd79262a85161764a97aaca89c3e4f574340ab61430cefa2bdd2c1/ruff-0.15.19-py3-none-win32.whl", hash = "sha256:8f47f0f92952af2557212bb10cf3e695cd4cf28b2c6e42cdb18ec6c9ebfa19da", size = 10986299, upload-time = "2026-06-24T01:10:55.185Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e8/15fd23e02b2442b56b2026b455977bc3057aa34b26e6323d1e99e8531a9f/ruff-0.15.19-py3-none-win_amd64.whl", hash = "sha256:efeca47ee3f9d4a7162655a3b8e6ee4a878646044233978d4d2c1ff8cdd914f0", size = 12123473, upload-time = "2026-06-24T01:10:27.74Z" },
+    { url = "https://files.pythonhosted.org/packages/30/66/9a73695e31eaee04f35d8475998bf8ab354465f9c638936d76111603dcc5/ruff-0.15.19-py3-none-win_arm64.whl", hash = "sha256:6c6b607466e47349332eb1d9be52fb1467423fc07c217341af41cd0f3f0573be", size = 11376779, upload-time = "2026-06-24T01:10:34.465Z" },
 ]
 
 [[package]]
 name = "s3transfer"
-version = "0.17.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]
@@ -1356,14 +1411,39 @@ wheels = [
 
 [[package]]
 name = "tqdm"
-version = "4.67.3"
+version = "4.68.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.53"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/87/d5a1d099a41ed22f939b9eec5af3c40bd907409e673cc0b8fcfd1e354ab2/ty-0.0.53.tar.gz", hash = "sha256:86e8c522b1a1ae267cd6442cc93c0c954a2a59b89565e4fb493c1133bd5a056e", size = 5998692, upload-time = "2026-06-24T06:53:57.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/4a/1364826b7747a6ca6de4c3b1a47b6ed6e4d27d76236c704f02ccc2624686/ty-0.0.53-py3-none-linux_armv6l.whl", hash = "sha256:637f3c8e4837973c530d659cbd9a6697c12141b61b458214570a95048064acf5", size = 12034508, upload-time = "2026-06-24T06:53:18.729Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/55/9edc86267086c1d0be32b0625f2cae4bd269f62e9f0084f5469d5a7ada9e/ty-0.0.53-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5b1079f5f18667362e6a2df0c08eef83b99cc7ec1f1e6bd6a43eb17087a62da2", size = 11793873, upload-time = "2026-06-24T06:53:21.188Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9b/92f080253ca27ad60f4a982f1d6e67fce1ab117514b8b51a25ed3e64a6b2/ty-0.0.53-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0699807f3333c052120998d0f652f9e13d534b16cbb4f04397885569e2889e5", size = 11190702, upload-time = "2026-06-24T06:53:23.216Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5b/fb3727c810bc9d131e74f21ed23ab04b2f6027a34f6399528c1adf1fc48c/ty-0.0.53-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fded06aeb8fbb0eb30d3164bba6d42446ca0f92268bd13668e636d984ff5ae32", size = 11711062, upload-time = "2026-06-24T06:53:25.312Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/0b/e542864d10d84f6bd7e19b76578cb1f80ef83aac208f3dc0cafdf22ce924/ty-0.0.53-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4c890c34364d020f9aead3737fd00b06bb57981d5689825dd7face9caf89b92", size = 11801237, upload-time = "2026-06-24T06:53:27.437Z" },
+    { url = "https://files.pythonhosted.org/packages/75/61/f00b26d3618b8e4399d7b86a380867ff62ade8347650234fd50f74585863/ty-0.0.53-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aeb2d2be32efc1c937551b5bdb6f94c96b330baac9cc12e69a91c82d2fdad5d9", size = 12324525, upload-time = "2026-06-24T06:53:29.537Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/01/63ce174e9a330e2c90f829fe523c737c2ecc7b5504a7a43f44866069e0fd/ty-0.0.53-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b175ce1a92e382991341a9ad2760de5d87b7b88c509a6ac26cbfcd5c723a3179", size = 12925679, upload-time = "2026-06-24T06:53:31.912Z" },
+    { url = "https://files.pythonhosted.org/packages/14/98/129a2cd39b0e5ba72b748b46134fd278c749802389899eefc9320689e39c/ty-0.0.53-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c9a145dfe24bb0be4a99d10480ccc0c7e5a7e36cf371d0a57bd7001cfd9bef5", size = 12551302, upload-time = "2026-06-24T06:53:33.993Z" },
+    { url = "https://files.pythonhosted.org/packages/23/0a/778deab4b31e3f6879073c668a4851de41f96174b5ff6bc8971c7d01d7b3/ty-0.0.53-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0664e9f707a4937e292ae83403e0486f610107b76f25e0987fec1bcda04121", size = 12353792, upload-time = "2026-06-24T06:53:36.347Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d2/f0823fd73233b9fdec9f90af2069b4a05f86b57da3bf274bd18744e8a1be/ty-0.0.53-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9eef1fc8e273f946103b264431ef314b72d2cbf50f0ef790f09fd308ec061259", size = 12600311, upload-time = "2026-06-24T06:53:38.615Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/ac64b9253223379b2e8e34900d852b3f561d5bb1b818caafda64f561fe79/ty-0.0.53-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d0afb96763442dc3dead88573e24d991bee9d4c52dbb57dee4c900c401dc269b", size = 11671972, upload-time = "2026-06-24T06:53:40.893Z" },
+    { url = "https://files.pythonhosted.org/packages/55/1a/dc83c6b89683cc18a060611f7e7836abb3211744ace1ab0174cb96533a7b/ty-0.0.53-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f56edd323fcf95801c9487dd85e3b7bb329313adcd58d8d057b0823e30b579c4", size = 11832266, upload-time = "2026-06-24T06:53:43.048Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e3/7c11d218da1b5ccadf4b6ddab83b54333703e0bcdadb1d912093c16324fb/ty-0.0.53-py3-none-musllinux_1_2_i686.whl", hash = "sha256:93f13cc1616fcf38df280263631121770e915d823b66b82a13a12d4e43bafb37", size = 11974033, upload-time = "2026-06-24T06:53:45.387Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/bb/af534430d07cf26b30f7ca76ac0f34df11bc3957d92eb29597ffa803626b/ty-0.0.53-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:de583808d93f7b6c93e1841deb4db5b181d8a7a1503c674f8143d6e06f2c67a2", size = 12462111, upload-time = "2026-06-24T06:53:47.76Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/0ba395d495669d2c022f8c0df4451ec0fc8f0d81fbc5d4fcf6f4f25ab98d/ty-0.0.53-py3-none-win32.whl", hash = "sha256:c58318cd7835aab2d1cd26d6995d3b776bf40800aa45eeb32e8e60e912863fc8", size = 11297877, upload-time = "2026-06-24T06:53:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/49/7fe9cec8f0e35b71e6935d753c8c7acf7731f787355b5f6a85f10f9f07bb/ty-0.0.53-py3-none-win_amd64.whl", hash = "sha256:4e3e24605c960dc6ce8ee8cd2ccb6dee2a1acbbded96ac62329ee4f200605235", size = 12414620, upload-time = "2026-06-24T06:53:52.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f8/355b115b42f74bce0be582232a68b7e21d9cac43c77e005dfaa486e79873/ty-0.0.53-py3-none-win_arm64.whl", hash = "sha256:ea0e13311c6f386b36f1c76be114121a1ad7da38f025b143ae193899816ca791", size = 11772715, upload-time = "2026-06-24T06:53:55.132Z" },
 ]
 
 [[package]]
@@ -1386,7 +1466,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.3.3"
+version = "21.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1394,7 +1474,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/a5/81f987504738e6defeed61ec1c47e2aefab3c35d8eeb87e1b3f38cf28254/virtualenv-21.5.1.tar.gz", hash = "sha256:dca3bf98275a59c652b69d68e73433e597d977c2da9198882479d1a7188009c8", size = 4578798, upload-time = "2026-06-16T16:23:58.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl", hash = "sha256:55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783", size = 4558820, upload-time = "2026-06-16T16:23:56.963Z" },
 ]


### PR DESCRIPTION
This PR adds [`ty`](https://docs.astral.sh/ty/) as a type-checker, tightens `ruff` rules, and applies necessary changes to satisfy both `ruff` and `ty` to the codebase. The pre-commit has also been updated with additional hooks, and now includes the `ty-pre-commit` hook. 

Other changes include:
* Switch to absolute imports across all modules
* Fixes to some previously uncaught bugs and references.
* Update CI to also use `ruff` and `ty` to enforce code quality
* Add benchmark ci concurrency (unrelated, but to prevent multiple benchmarks from running at the same time)