### PR TITLE
fix: `AnyPath` for py311

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,7 @@ jobs:
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: ${{ matrix.python-version }}
-      - run: uv sync --all-extras
-
+      - run: uv sync --all-extras --no-extra cloud
       - name: Run non-cloud tests
         run: |
           uv run pytest \
@@ -52,6 +51,7 @@ jobs:
             --cov=bids2table \
             tests
 
+      - run: uv sync --all-extras
       - name: Run cloud tests
         run: |
           uv run pytest \

--- a/bids2table/_pathlib.py
+++ b/bids2table/_pathlib.py
@@ -18,11 +18,7 @@ try:
 
 except Exception:
     # Assignment of cloudpath classes if cloudpathlib is unavailable
-    class CloudPath(Path):
-        pass
-
-    class AnyPath(Path):
-        pass
+    AnyPath = CloudPath = Path  # ty:ignore[invalid-assignment] # needed for py311
 
     _CLOUDPATHLIB_AVAILABLE = False
 


### PR DESCRIPTION
Switching to the class inheritance for AnyPath raises an error due to a missing attribute in py311 when cloud extras aren't installed. This PR reverts the assignment to the method from [`v2.2.1`](https://github.com/childmindresearch/bids2table/releases#release-v2.2.1).

CI did not catch this as all extras were always installed during testing. Also update the CI to skip the cloud extra dependency group when running non-cloud tests

Closes #115 